### PR TITLE
Router should not prevent default if meta keys are held down

### DIFF
--- a/packages/sycamore-router/Cargo.toml
+++ b/packages/sycamore-router/Cargo.toml
@@ -24,9 +24,9 @@ features = [
   "EventTarget",
   "History",
   "HtmlAnchorElement",
+  "KeyboardEvent",
   "Location",
   "PopStateEvent",
   "Window",
-  "KeyboardEvent",
 ]
 version = "0.3"

--- a/packages/sycamore-router/Cargo.toml
+++ b/packages/sycamore-router/Cargo.toml
@@ -27,5 +27,6 @@ features = [
   "Location",
   "PopStateEvent",
   "Window",
+  "KeyboardEvent",
 ]
 version = "0.3"

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -3,7 +3,7 @@ use std::cell::RefCell;
 use sycamore::prelude::*;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys::{Element, HtmlAnchorElement};
+use web_sys::{Element, HtmlAnchorElement, KeyboardEvent};
 
 use crate::Route;
 
@@ -85,7 +85,10 @@ pub fn browser_router<R: Route>(render: impl Fn(R) -> Template<G> + 'static) -> 
                         let origin = a.origin();
                         let path = a.pathname();
                         let hash = a.hash();
-                        if Ok(origin) == location.origin() {
+
+                        let meta_keys_pressed =
+                            meta_keys_pressed(ev.unchecked_ref::<KeyboardEvent>());
+                        if !meta_keys_pressed && Ok(origin) == location.origin() {
                             if Ok(&path) != location.pathname().as_ref() {
                                 // Same origin, different path.
                                 ev.prevent_default();
@@ -145,4 +148,8 @@ pub fn navigate(url: &str) {
             .push_state_with_url(&JsValue::UNDEFINED, "", Some(pathname.get().as_str()))
             .unwrap();
     });
+}
+
+fn meta_keys_pressed(kb_event: &KeyboardEvent) -> bool {
+    kb_event.meta_key() || kb_event.ctrl_key() || kb_event.shift_key() || kb_event.alt_key()
 }


### PR DESCRIPTION
This PR should close https://github.com/sycamore-rs/sycamore/issues/129.

I'm not 100% sure of the logic, because in the SvelteKit router code that was referenced in the issue (https://github.com/sveltejs/kit/blob/8854e2ffc48cf653854828f6ac19b2ce620535a6/packages/kit/src/runtime/client/router.js#L103), the key presses were checked immediately and if found the function immediately returned. So, in the code below, I skipped all of the subsequent logic if any of those keys were pressed. I'm not sure if the behavior is that we expect only the ```prevent_default``` from happening (in which case, I can update those two sections separately).