### PR TITLE
Explicitly enable std feature for indexmap

### DIFF
--- a/packages/sycamore/Cargo.toml
+++ b/packages/sycamore/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.5.1"
 [dependencies]
 chrono = {version = "0.4", features = ["wasmbind"]}
 html-escape = {version = "0.2.7", optional = true}
-indexmap = "1.7"
+indexmap = { version = "1.7.0", features = ["std"] }
 js-sys = {version = "0.3"}
 serde = {version = "1.0", optional = true}
 smallvec = "1.6"


### PR DESCRIPTION
In some environments, indexmap's detection of the std crate fails, causing sycamore builds to fail (IndexSet has a variable number of type arguments depending on this detection).
This pull request sets indexmap's std feature flag explicitly, negating the need for automatic detection.

See also:
* [indexmap issue](https://github.com/bluss/indexmap/issues/184)
* [similar issue in google/cargo-raze](https://github.com/google/cargo-raze/issues/114)
* [indexmap's has_std causing issues with intellij](https://github.com/intellij-rust/intellij-rust/issues/4631)
