### PR TITLE
fix logic error in `reconcile_fragments`

### DIFF
--- a/packages/sycamore/src/utils/render.rs
+++ b/packages/sycamore/src/utils/render.rs
@@ -273,7 +273,7 @@ pub fn reconcile_fragments<G: GenericNode>(parent: &G, a: &mut [G], b: &[G]) {
         } else if b_end == b_start {
             // Remove.
             while a_start < a_end {
-                if map.is_none() || map.as_ref().unwrap().contains_key(&a[a_start]) {
+                if map.is_none() || !map.as_ref().unwrap().contains_key(&a[a_start]) {
                     parent.remove_child(&a[a_start]);
                 }
                 a_start += 1;


### PR DESCRIPTION
I noticed when using the `Keyed` component that when the `KeyedProps::iterable`
value changed from a large `Vec` to a smaller one containing a subset of the
original, not all the obsolete nodes were removed from the DOM.

Specifically, I started with a `Vec` with 10 elements, then removed all but the
third one.  The nodes before the remaining node were removed, but not the ones
after it.  This patch fixes the problem.