### PR TITLE
Router integrations

### DIFF
--- a/docs/build.rs
+++ b/docs/build.rs
@@ -113,10 +113,6 @@ fn build_dir(base: &Path, output: &Path) -> Result<(), Box<dyn Error>> {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    println!("cargo:rerun-if-changed=next");
-    println!("cargo:rerun-if-changed=versioned_docs");
-    println!("cargo:rerun-if-changed=posts");
-
     build_dir(Path::new("./next"), Path::new("docs"))?;
     build_dir(Path::new("./versioned_docs"), Path::new("docs"))?;
     build_dir(Path::new("./posts"), Path::new("posts"))?;

--- a/docs/next/advanced/routing.md
+++ b/docs/next/advanced/routing.md
@@ -21,8 +21,8 @@ number for `sycamore` (e.g. `sycamore-router v0.5.x` is compatible with `sycamor
 
 ## Creating routes
 
-Start off by adding `use sycamore_router::{BrowserRouter, Route}` to the top of your source code.
-This imports the symbols needed to define our router.
+Start off by adding `use sycamore_router::{Router, Route}` to the top of your source code. This
+imports the symbols needed to define our router.
 
 The heart of the router is an `enum`. Each variant of the `enum` represents a different route. To
 make our `enum` usable with `BrowserRouter`, we will use the `Route` derive macro to implement the
@@ -157,13 +157,13 @@ Likewise, the
 [`FromSegments`](https://docs.rs/sycamore-router/latest/sycamore_router/trait.FromSegments.html)
 trait is the equivalent for dynamic segments.
 
-## Using `BrowserRouter`
+## Using `Router`
 
-To display content based on the route that matches, we can use a `BrowserRouter`.
+To display content based on the route that matches, we can use a `Router`.
 
 ```rust
 template! {
-    BrowserRouter(|route: AppRoutes| {
+    Router(RouterProps::new(HistoryIntegration::new(), |route: AppRoutes| {
         match route {
             AppRoutes::Index => template! {
                 "This is the index page"
@@ -179,23 +179,26 @@ template! {
 }
 ```
 
-`BrowserRouter` is just a component like any other. The props accept a closure taking the matched
-route as a parameter. Any clicks on anchor tags (`<a>`) created inside the `BrowserRouter` will be
-intercepted and handled by the router.
+`Router` is just a component like any other. The props accept a closure taking the matched route as
+a parameter and an "integration". The integration is for adapting the router to different
+environments (e.g. server-side rendering). The `HistoryIntegration` is a built-in integration that
+uses the [HTML5 History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API).
 
-## Using `StaticRouter`
+Any clicks on anchor tags (`<a>`) created inside the `Router` will be intercepted and handled by the
+router.
 
-Whereas `BrowserRouter` is used inside the context of a browser, `StaticRouter` is used for SSR.
+## Server-side rendering and `StaticIntegration`
 
-The difference between a `BrowserRouter` and a `StaticRouter` is that the url is provided to
-`StaticRouter` only during the initialization phase. The initial url is provided as an argument to
-`StaticRouter`.
+Whereas `HistoryIntegration` is used inside the context of a browser, `StaticIntegration` can be
+used for SSR.
+
+The difference between a `HistoryIntegration` and a `StaticIntegration` is that the url is provided
+to `StaticIntegration` during the initialization phase. The initial url is provided as an argument
+to `StaticIntegration::new`.
 
 ```rust
-use sycamore_router::{Route, StaticRouter};
-
 template! {
-    StaticRouter(("/about", |route: AppRoutes| {
+    Router(StaticIntegration::new("/about"), |route: AppRoutes| {
         match route {
             AppRoutes::Index => template! {
                 "This is the index page"
@@ -207,7 +210,7 @@ template! {
                 "404 Not Found"
             },
         }
-    }))
+    })
 }
 ```
 

--- a/docs/next/advanced/routing.md
+++ b/docs/next/advanced/routing.md
@@ -21,12 +21,12 @@ number for `sycamore` (e.g. `sycamore-router v0.5.x` is compatible with `sycamor
 
 ## Creating routes
 
-Start off by adding `use sycamore_router::{Router, Route}` to the top of your source code. This
-imports the symbols needed to define our router.
+Start off by adding `use sycamore_router::{Route, Router, RouterProps}` to the top of your source
+code. This imports the symbols needed to define our router.
 
 The heart of the router is an `enum`. Each variant of the `enum` represents a different route. To
-make our `enum` usable with `BrowserRouter`, we will use the `Route` derive macro to implement the
-required traits for us.
+make our `enum` usable with `Router`, we will use the `Route` derive macro to implement the required
+traits for us.
 
 Here is an example:
 
@@ -213,6 +213,10 @@ template! {
     })
 }
 ```
+
+## Integrations
+
+TODO: docs for creating custom router integrations.
 
 ## Using `navigate`
 

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -72,6 +72,8 @@ impl Integration for StaticIntegration {
 /// UI in sync with the URL.
 #[derive(Default)]
 pub struct HistoryIntegration {
+    /// This field is to prevent downstream users from creating a new `HistoryIntegration` without
+    /// the `new` method.
     _internal: (),
 }
 

--- a/packages/sycamore/src/generic_node.rs
+++ b/packages/sycamore/src/generic_node.rs
@@ -60,7 +60,8 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
 
     /// Sets the `class` attribute on a node.
     /// This should have the same outcome as calling `set_attribute("class", value)`.
-    /// For [`DomNode`], this sets the `className` property directly which is about 2x faster (on Chrome).
+    /// For [`DomNode`], this sets the `className` property directly which is about 2x faster (on
+    /// Chrome).
     fn set_class_name(&self, value: &str);
 
     /// Sets a property on a node.

--- a/packages/sycamore/tests/ssr/main.rs
+++ b/packages/sycamore/tests/ssr/main.rs
@@ -49,5 +49,8 @@ fn fragments() {
         p { "3" }
     };
 
-    assert_eq!(sycamore::render_to_string(|| node), "<p>1</p><p>2</p><p>3</p>");
+    assert_eq!(
+        sycamore::render_to_string(|| node),
+        "<p>1</p><p>2</p><p>3</p>"
+    );
 }


### PR DESCRIPTION
Closes #123 

This PR introduces the new `Integration` trait that abstracts over the browser's History API.
This also introduces `HistoryIntegration` and `StaticIntegration` for client-side and server-side routing respectively.