### PR TITLE
Rename rx to reactive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ Cargo.lock
 
 # Local Netlify folder
 .netlify
+
+# VS Code folder
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "cSpell.words": [
-        "changefreq"
-    ]
-}

--- a/docs/next/advanced/advanced_reactivity.md
+++ b/docs/next/advanced/advanced_reactivity.md
@@ -21,11 +21,12 @@ and a `children` prop which is the child components that have access to the cont
 
 ```rust
 use sycamore::prelude::*;
-use sycamore::rx::{ContextProvider, ContextProviderProps, use_context};
+use sycamore::context::{ContextProvider, ContextProviderProps, use_context};
 
+#[derive(Clone)]
 struct Counter(Signal<i32>);
 
-#[component(CounterView)]
+#[component(CounterView<G>)]
 fn counter_view() -> Template<G> {
     let counter = use_context::<Counter>();
 

--- a/docs/next/contribute/architecture.md
+++ b/docs/next/contribute/architecture.md
@@ -7,7 +7,7 @@ All non proc-macro related code is in `/packages/sycamore`. Proc-macro related c
 
 - #### Reactivity
 
-  - All the reactivity primitives are defined in `/packages/sycamore/src/rx.rs`.
+  - All the reactivity primitives are defined in live in the `sycamore-reactive` crate.
 
 - #### `GenericNode`
 

--- a/examples/context/src/main.rs
+++ b/examples/context/src/main.rs
@@ -1,6 +1,6 @@
 use sycamore::context::{ContextProvider, ContextProviderProps};
 use sycamore::prelude::*;
-use sycamore::rx::use_context;
+use sycamore::reactive::use_context;
 
 #[component(Counter<G>)]
 fn counter() -> Template<G> {

--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -6,7 +6,8 @@ mod template;
 
 /// A macro for ergonomically creating complex UI structures.
 ///
-/// TODO: write some more docs
+/// To learn more about the template syntax, see the chapter on
+/// [the `template!` macro](https://sycamore-rs.netlify.app/docs/basics/template) in the Sycamore Book.
 #[proc_macro]
 pub fn template(component: TokenStream) -> TokenStream {
     let component = parse_macro_input!(component as template::HtmlRoot);
@@ -15,6 +16,11 @@ pub fn template(component: TokenStream) -> TokenStream {
 }
 
 /// A macro for creating components from functions.
+///
+/// Add this attribute to a `fn` to create a component from that function.
+///
+/// To learn more about components, see the chapter on
+/// [components](https://sycamore-rs.netlify.app/docs/basics/components) in the Sycamore Book.
 #[proc_macro_attribute]
 pub fn component(attr: TokenStream, component: TokenStream) -> TokenStream {
     let attr = parse_macro_input!(attr as component::ComponentFunctionName);

--- a/packages/sycamore-macro/src/template/attributes.rs
+++ b/packages/sycamore-macro/src/template/attributes.rs
@@ -125,7 +125,7 @@ impl ToTokens for Attribute {
 
                 if is_dynamic {
                     tokens.extend(quote_spanned! { expr_span=>
-                        ::sycamore::rx::create_effect({
+                        ::sycamore::reactive::create_effect({
                             let __el = ::std::clone::Clone::clone(&__el);
                             move || {
                                 #quoted_set_attribute
@@ -143,7 +143,7 @@ impl ToTokens for Attribute {
             AttributeType::DangerouslySetInnerHtml => {
                 if is_dynamic {
                     tokens.extend(quote_spanned! { expr_span=>
-                        ::sycamore::rx::create_effect({
+                        ::sycamore::reactive::create_effect({
                             let __el = ::std::clone::Clone::clone(&__el);
                             move || {
                                 ::sycamore::generic_node::GenericNode::dangerously_set_inner_html(
@@ -229,9 +229,9 @@ impl ToTokens for Attribute {
                 };
 
                 tokens.extend(quote_spanned! { expr_span=> {
-                    let signal: ::sycamore::rx::Signal<#value_ty> = #expr;
+                    let signal: ::sycamore::reactive::Signal<#value_ty> = #expr;
 
-                    ::sycamore::rx::create_effect({
+                    ::sycamore::reactive::create_effect({
                         let signal = ::std::clone::Clone::clone(&signal);
                         let __el = ::std::clone::Clone::clone(&__el);
                         move || {

--- a/packages/sycamore-macro/src/template/component.rs
+++ b/packages/sycamore-macro/src/template/component.rs
@@ -35,13 +35,13 @@ impl ToTokens for Component {
 
         let quoted = if args.empty_or_trailing() {
             quote_spanned! { paren.span=>
-                ::sycamore::rx::untrack(||
+                ::sycamore::reactive::untrack(||
                     #path::<_>::__create_component#generics(())
                 )
             }
         } else {
             quote_spanned! { path.span()=>
-                ::sycamore::rx::untrack(||
+                ::sycamore::reactive::untrack(||
                     #path::<_>::__create_component#generics(#args)
                 )
             }

--- a/packages/sycamore-reactive/src/effect.rs
+++ b/packages/sycamore-reactive/src/effect.rs
@@ -200,7 +200,8 @@ fn _create_effect(mut effect: Box<dyn FnMut()>) {
                 let listener = listener.as_ref().unwrap();
 
                 // Unsubscribe from removed dependencies.
-                // Removed dependencies are those that are in old dependencies but not in new dependencies.
+                // Removed dependencies are those that are in old dependencies but not in new
+                // dependencies.
                 for old_dependency in old_dependencies.difference(&listener.dependencies) {
                     old_dependency
                         .signal()
@@ -208,7 +209,8 @@ fn _create_effect(mut effect: Box<dyn FnMut()>) {
                 }
 
                 // Subscribe to new dependencies.
-                // New dependencies are those that are in new dependencies but not in old dependencies.
+                // New dependencies are those that are in new dependencies but not in old
+                // dependencies.
                 for new_dependency in listener.dependencies.difference(&old_dependencies) {
                     new_dependency.signal().subscribe(Callback(Rc::downgrade(
                         // Reference the same closure we are in right now.
@@ -286,6 +288,18 @@ where
 /// the same. That is why the output of the function must implement [`PartialEq`].
 ///
 /// To specify a custom comparison function, use [`create_selector_with`].
+///
+/// # Example
+/// ```rust
+/// use sycamore_reactive::*;
+///
+/// let state = Signal::new(0);
+/// let double = create_selector(cloned!((state) => move || *state.get() * 2));
+/// assert_eq!(*double.get(), 0);
+///
+/// state.set(1);
+/// assert_eq!(*double.get(), 2);
+/// ```
 #[inline]
 pub fn create_selector<F, Out>(derived: F) -> StateHandle<Out>
 where

--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -17,6 +17,17 @@ pub struct StateHandle<T: 'static>(Rc<RefCell<SignalInner<T>>>);
 impl<T: 'static> StateHandle<T> {
     /// Get the current value of the state. When called inside a reactive scope, calling this will
     /// add itself to the scope's dependencies.
+    ///
+    /// # Example
+    /// ```rust
+    /// use sycamore_reactive::*;
+    ///
+    /// let state = Signal::new(0);
+    /// assert_eq!(*state.get(), 0);
+    ///
+    /// state.set(1);
+    /// assert_eq!(*state.get(), 1);
+    /// ```
     pub fn get(&self) -> Rc<T> {
         // If inside an effect, add this signal to dependency list.
         // If running inside a destructor, do nothing.

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 
 use sycamore::generic_node::EventHandler;
 use sycamore::prelude::*;
-use sycamore::rx::ReactiveScope;
+use sycamore::reactive::ReactiveScope;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;

--- a/packages/sycamore/benches/reactivity.rs
+++ b/packages/sycamore/benches/reactivity.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use sycamore::prelude::*;
-use sycamore::rx::{map_indexed, map_keyed};
+use sycamore::reactive::{map_indexed, map_keyed};
 
 pub fn bench(c: &mut Criterion) {
     c.bench_function("reactivity_signals", |b| {

--- a/packages/sycamore/src/context.rs
+++ b/packages/sycamore/src/context.rs
@@ -1,4 +1,5 @@
 use sycamore_reactive::create_context_scope;
+pub use sycamore_reactive::use_context;
 
 use crate::prelude::*;
 
@@ -14,6 +15,36 @@ where
 }
 
 /// Creates a new [`ReactiveScope`] with a context.
+///
+/// # Example
+/// ```rust
+/// use sycamore::prelude::*;
+/// use sycamore::context::{ContextProvider, ContextProviderProps, use_context};
+///
+/// #[derive(Clone)]
+/// struct Counter(Signal<i32>);
+///
+/// #[component(CounterView<G>)]
+/// fn counter_view() -> Template<G> {
+///     let counter = use_context::<Counter>();
+///
+///     template! {
+///         (counter.0.get())
+///     }
+/// }
+///
+/// # #[component(App<G>)]
+/// # fn app() -> Template<G> {
+/// template! {
+///     ContextProvider(ContextProviderProps {
+///         value: Counter(Signal::new(0)),
+///         children: || template! {
+///             CounterView()
+///         }
+///     })
+/// }
+/// # }
+/// ```
 #[component(ContextProvider<G>)]
 pub fn context_provider<T, F>(props: ContextProviderProps<T, F, G>) -> Template<G>
 where

--- a/packages/sycamore/src/flow.rs
+++ b/packages/sycamore/src/flow.rs
@@ -7,7 +7,7 @@ use std::hash::Hash;
 
 use crate::generic_node::GenericNode;
 use crate::prelude::*;
-use crate::rx::{map_indexed, map_keyed};
+use crate::reactive::{map_indexed, map_keyed};
 
 /// Props for [`Keyed`].
 pub struct KeyedProps<T: 'static, F, G: GenericNode, K, Key>

--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -10,7 +10,7 @@ use wasm_bindgen::{intern, JsCast};
 use web_sys::{Comment, Element, Node, Text};
 
 use crate::generic_node::{EventHandler, GenericNode};
-use crate::rx::{create_root, on_cleanup, ReactiveScope};
+use crate::reactive::{create_root, on_cleanup, ReactiveScope};
 use crate::template::Template;
 use crate::utils::render::insert;
 

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -9,7 +9,7 @@ use ahash::AHashMap;
 use wasm_bindgen::prelude::*;
 
 use crate::generic_node::{EventHandler, GenericNode};
-use crate::rx::create_root;
+use crate::reactive::create_root;
 use crate::template::Template;
 
 static VOID_ELEMENTS: &[&str] = &[

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -21,7 +21,7 @@
 #![deny(clippy::type_repetition_in_bounds)]
 
 pub use sycamore_macro::{component, template};
-pub use sycamore_reactive as rx;
+pub use sycamore_reactive as reactive;
 
 pub mod component;
 pub mod context;
@@ -52,7 +52,7 @@ pub mod prelude {
     #[cfg(feature = "ssr")]
     pub use crate::generic_node::SsrNode;
     pub use crate::noderef::NodeRef;
-    pub use crate::rx::{
+    pub use crate::reactive::{
         cloned, create_effect, create_memo, create_root, create_selector, create_selector_with,
         on_cleanup, untrack, Signal, StateHandle,
     };

--- a/packages/sycamore/src/motion.rs
+++ b/packages/sycamore/src/motion.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 
 use chrono::{prelude::*, Duration};
 
-use crate::rx::Signal;
+use crate::reactive::Signal;
 use crate::utils::{loop_raf, Task};
 
 /// Describes a trait that can be linearly interpolate between two points.

--- a/packages/sycamore/src/template.rs
+++ b/packages/sycamore/src/template.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::rc::Rc;
 
 use crate::generic_node::GenericNode;
-use crate::rx::{create_memo, StateHandle};
+use crate::reactive::{create_memo, StateHandle};
 
 /// Internal type for [`Template`].
 #[derive(Clone)]

--- a/packages/sycamore/src/utils/render.rs
+++ b/packages/sycamore/src/utils/render.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use ahash::AHashMap;
 
 use crate::generic_node::GenericNode;
-use crate::rx::create_effect;
+use crate::reactive::create_effect;
 use crate::template::{Template, TemplateType};
 
 /// Insert a [`GenericNode`] under `parent` at the specified `marker`. If `initial` is `Some(_)`,


### PR DESCRIPTION
`rx` is ambiguous with ReactiveX-family of libraries: http://reactivex.io/