### PR TITLE
Explain that Trunk needs a HTML source file

### DIFF
--- a/docs/versioned_docs/v0.5/getting_started/hello_world.md
+++ b/docs/versioned_docs/v0.5/getting_started/hello_world.md
@@ -1,7 +1,6 @@
 # Hello, World!
 
-Sycamore tries to have as simple of an API as possible. In fact, the Hello World program in Sycamore
-is but slightly longer than the console version!
+Sycamore tries to have as simple of an API as possible.
 
 Here it is:
 
@@ -49,7 +48,22 @@ we want to render the following HTML:
 The `p { ... }` creates a new `<p>` tag. The `"Hello, World!"` creates a new text node that is
 nested within the `<p>` tag.
 
-There it is! To try it out, copy the Hello World code snippet to your `main.rs` file and run
+There it is! Trunk just needs one thing to turn this into a website; a html source file to inject the 
+template into. Copy the following code to a file called `index.html` in the root of your crate 
+(alongside `Cargo.toml`):
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>My first Sycamore app</title>
+</head>
+<body></body>
+</html>
+```
+
+To try it out, copy the Hello World code snippet to your `main.rs` file and run
 `trunk serve` from your command prompt. Open up your browser at `localhost:8080` and you should see
 _"Hello, World!"_ printed to the screen in all its glory.
 


### PR DESCRIPTION
Hi! Just exploring Sycamore (looks cool so far) and ran into trouble running the hello world example, which doesn't describe creating index.html, which Trunk needs. Following the current instructions gives an error:

```
$ trunk serve                        
Error: error getting canonical path to source HTML file "index.html"

Caused by:
    No such file or directory (os error 2)
```

So I thought I'd fix that :)

The page in question also previously said:

> In fact, the Hello World program in Sycamore is but slightly longer than the console version!

But the console version is not described. So I've removed this sentence.

Finally, the description of the sycamore repo on Github is

> A reactive DOM library for Rust in WASM 

I only mention this in case you wanted to update it to "Sycamore is a modern VDOM-less web library with fine-grained reactivity in Rust and WebAssembly." to match the readme.

Thanks!