### PR TITLE
Derived `Clone` for router types

### DIFF
--- a/packages/sycamore-router/src/lib.rs
+++ b/packages/sycamore-router/src/lib.rs
@@ -33,6 +33,7 @@ pub trait Route: Sized {
 }
 
 /// Represents an URL segment or segments.
+#[derive(Clone)]
 pub enum Segment {
     /// Match a specific segment.
     Param(String),
@@ -43,7 +44,7 @@ pub enum Segment {
 }
 
 /// Represents a capture of an URL segment or segments.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Capture<'a> {
     DynParam(&'a str),
     DynSegments(Vec<&'a str>),
@@ -68,6 +69,7 @@ impl<'a> Capture<'a> {
 }
 
 /// A list of [`Segment`]s.
+#[derive(Clone)]
 pub struct RoutePath {
     segments: Vec<Segment>,
 }


### PR DESCRIPTION
This just derives the `Clone` trait for the `sycamore-router` types `Segment`, `Capture`, and `RoutePath`, which makes it much easier to work with the routing internals.

This fixes #230.