### PR TITLE
Do not intercept anchors with `rel="external"`

### DIFF
--- a/docs/next/advanced/routing.md
+++ b/docs/next/advanced/routing.md
@@ -274,3 +274,15 @@ template! {
     }
 }
 ```
+
+## `rel="external"`
+
+By default, the router will intercept all `<a>` elements that have the same origin as the current
+page. Sometimes, we just want the browser to handle navigation without being intercepted by the
+router. To bypass the router, we can add the `rel="external"` attribute to the anchor tag.
+
+```rust
+template! {
+    a(href="path", rel="external") { "Path" }
+}
+```

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -71,6 +71,13 @@ impl Integration for HistoryIntegration {
                 let location = web_sys::window().unwrap().location();
 
                 let a = a.unchecked_into::<HtmlAnchorElement>();
+
+                // Check if a has `rel="external"`.
+                if a.rel() == "external" {
+                    // Use default browser behaviour.
+                    return;
+                }
+
                 let origin = a.origin();
                 let path = a.pathname();
                 let hash = a.hash();

--- a/website/src/versions.rs
+++ b/website/src/versions.rs
@@ -52,6 +52,7 @@ fn versioned_docs_link_view(
             a(
                 class="hover:text-yellow-500 transition-colors",
                 href="/api/sycamore/index.html",
+                rel="external"
             ) { "API" }
         },
     }


### PR DESCRIPTION
Adding `rel="external"` to an anchor element (`<a>`) will prevent the router from intercepting the click and let the browser perform the default navigation behavior.

This is useful when there are other pages that are hosted on the same origin but are not managed by the router.