### PR TITLE
Update docs to use boolean for disabled attribute on button

### DIFF
--- a/docs/next/basics/template.md
+++ b/docs/next/basics/template.md
@@ -56,7 +56,7 @@ Attributes (including classes and ids) can also be specified.
 ```rust
 template! {
     p(class="my-class", id="my-paragraph", aria-label="My paragraph")
-    button(disabled="true") {
+    button(disabled=true) {
        "My button"
     }
 }

--- a/docs/versioned_docs/v0.5/basics/template.md
+++ b/docs/versioned_docs/v0.5/basics/template.md
@@ -23,7 +23,7 @@ template! {
 }
 
 template! {
-    button(disabled="true") {
+    button(disabled=true) {
        "My button"
     }
 }

--- a/docs/versioned_docs/v0.5/basics/template.md
+++ b/docs/versioned_docs/v0.5/basics/template.md
@@ -23,7 +23,7 @@ template! {
 }
 
 template! {
-    button(disabled=true) {
+    button(disabled="true") {
        "My button"
     }
 }

--- a/docs/versioned_docs/v0.6/basics/template.md
+++ b/docs/versioned_docs/v0.6/basics/template.md
@@ -56,7 +56,7 @@ Attributes (including classes and ids) can also be specified.
 ```rust
 template! {
     p(class="my-class", id="my-paragraph", aria-label="My paragraph")
-    button(disabled="true") {
+    button(disabled=true) {
        "My button"
     }
 }


### PR DESCRIPTION
Going through [docs](https://sycamore-rs.netlify.app/docs/basics/template#attributes) came across this 
and Rust compiler complained, hence this update.

<img width="590" alt="Screenshot 2021-09-17 at 16 36 24" src="https://user-images.githubusercontent.com/816941/133801651-9fdc8d3a-299f-47c1-9c4a-4a6d173fcea3.png">
