### PR TITLE
Added node! convenience macro

### DIFF
--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -16,15 +16,13 @@ pub fn template(component: TokenStream) -> TokenStream {
 }
 
 /// ```
-/// use sycamore::{generic_node::EventHandler, prelude::*};
+/// use sycamore::prelude::*;
 ///
 /// #[component(MyComponent<G>)]
-/// pub fn my_component(event_listeners: Vec<(String, Box<EventHandler>)>) -> Template<G> {
+/// pub fn my_component() -> Template<G> {
 ///     let cool_button: G = node! { button { "The coolest 😎" } };
 ///
-///     for listener in event_listeners {
-///         cool_button.event(listener.0.as_ref(), listener.1);
-///     }
+///     cool_button.set_property("myProperty", &"Epic!".into());
 ///
 ///     Template::new_node(cool_button)
 /// }

--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -15,6 +15,27 @@ pub fn template(component: TokenStream) -> TokenStream {
     template::template_impl(component).into()
 }
 
+/// ```
+/// use sycamore::{generic_node::EventHandler, prelude::*};
+///
+/// #[component(MyComponent<G>)]
+/// pub fn my_component(event_listeners: Vec<(String, Box<EventHandler>)>) -> Template<G> {
+///     let cool_button: G = node! { button { "The coolest 😎" } };
+///
+///     for listener in event_listeners {
+///         cool_button.event(listener.0.as_ref(), listener.1);
+///     }
+///
+///     Template::new_node(cool_button)
+/// }
+/// ```
+#[proc_macro]
+pub fn node(input: TokenStream) -> TokenStream {
+    let node = parse_macro_input!(input as template::Element);
+
+    template::node_impl(node).into()
+}
+
 /// A macro for creating components from functions.
 ///
 /// Add this attribute to a `fn` to create a component from that function.

--- a/packages/sycamore-macro/src/template/mod.rs
+++ b/packages/sycamore-macro/src/template/mod.rs
@@ -9,7 +9,7 @@ mod splice;
 use attributes::*;
 use children::*;
 use component::*;
-use element::*;
+pub use element::Element;
 use splice::*;
 
 use proc_macro2::TokenStream;
@@ -139,4 +139,8 @@ impl ToTokens for HtmlRoot {
 
 pub fn template_impl(component: HtmlRoot) -> TokenStream {
     component.to_token_stream()
+}
+
+pub fn node_impl(html: Element) -> TokenStream {
+    html.to_token_stream()
 }

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -20,7 +20,7 @@
 #![deny(clippy::trait_duplication_in_bounds)]
 #![deny(clippy::type_repetition_in_bounds)]
 
-pub use sycamore_macro::{component, template};
+pub use sycamore_macro::{component, node, template};
 pub use sycamore_reactive as reactive;
 
 pub mod component;
@@ -44,7 +44,7 @@ pub use crate::generic_node::{render_to_string, SsrNode};
 
 /// The sycamore prelude.
 pub mod prelude {
-    pub use sycamore_macro::{component, template};
+    pub use sycamore_macro::{component, node, template};
 
     pub use crate::flow::{Indexed, IndexedProps, Keyed, KeyedProps};
     #[cfg(feature = "dom")]


### PR DESCRIPTION
This macro works well for cases where we need access to underlying `GenericNode` operations, such as `.event()`, `.add_attribute()`, `.remove_attribute` that cannot currently be performed inside of the `template!` macro, yet retain the ergonomics for setting attributes and children that don't need the extra flexibility. Please see the `doc example` below for a possible use case.

This is also a good workaround for #264.