### PR TITLE
Added `remove_property` method to `GenericNode`

### DIFF
--- a/packages/sycamore/src/generic_node.rs
+++ b/packages/sycamore/src/generic_node.rs
@@ -70,6 +70,9 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
     /// Sets a property on a node.
     fn set_property(&self, name: &str, value: &JsValue);
 
+    /// Removes a property on a node.
+    fn remove_property(&self, name: &str);
+
     /// Appends a child to the node's children.
     fn append_child(&self, child: &Self);
 

--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -181,6 +181,10 @@ impl GenericNode for DomNode {
         assert!(js_sys::Reflect::set(&self.node, &name.into(), value).unwrap_throw());
     }
 
+    fn remove_property(&self, name: &str) {
+        assert!(js_sys::Reflect::delete_property(&self.node, &name.into()).unwrap_throw());
+    }
+
     fn append_child(&self, child: &Self) {
         self.node.append_child(&child.node).unwrap_throw();
     }

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -153,6 +153,10 @@ impl GenericNode for SsrNode {
         // Noop.
     }
 
+    fn remove_property(&self, _name: &str) {
+        // Noop.
+    }
+
     fn append_child(&self, child: &Self) {
         child.set_parent(Rc::downgrade(&self.0));
 


### PR DESCRIPTION
This is useful to have, especially for some serializers which require certain properties to not exist, not just be `undefined`.