### PR TITLE
Remove prefix strip of path for `HistoryIntegration`

### DIFF
--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -93,7 +93,6 @@ impl Integration for HistoryIntegration {
                         ev.prevent_default();
                         PATHNAME.with(|pathname| {
                             let pathname = pathname.borrow().clone().unwrap_throw();
-                            let path = path.strip_prefix(&base_pathname()).unwrap_or(&path);
                             pathname.set(path.to_string());
 
                             // Update History API.


### PR DESCRIPTION
This resolves the bug mentioned in #270. Close instead of merging if there's a need for this line that I'm not aware of.