### PR TITLE
Add `IS_BROWSER` constant to `GenericNode`

### DIFF
--- a/packages/sycamore-macro/src/component/mod.rs
+++ b/packages/sycamore-macro/src/component/mod.rs
@@ -168,7 +168,7 @@ pub fn component_impl(
     let component_name_str = component_name.to_string();
     let generic_node_ty = generic_node_ty.type_params().next().unwrap();
     let generic_node: GenericParam = syn::parse_quote! {
-        #generic_node_ty: ::sycamore::generic_node::GenericNode
+        #generic_node_ty: ::sycamore::generic_node::Html
     };
 
     let ComponentFunction {
@@ -187,7 +187,7 @@ pub fn component_impl(
         FnArg::Typed(pat_ty) => &pat_ty.ty,
     };
 
-    // Add the GenericNode type param to generics.
+    // Add the Html type param to generics.
     let first_generic_param_index = generics
         .params
         .iter()

--- a/packages/sycamore-macro/src/template/component.rs
+++ b/packages/sycamore-macro/src/template/component.rs
@@ -37,7 +37,7 @@ impl ToTokens for Component {
             syn::PathArguments::None => quote! {},
             syn::PathArguments::AngleBracketed(mut generics) => {
                 if !generics.args.is_empty() {
-                    // Add the GenericNode type param to generics.
+                    // Add the Html type param to generics.
                     let first_generic_param_index = generics
                         .args
                         .iter()

--- a/packages/sycamore-macro/tests/template/component-fail.rs
+++ b/packages/sycamore-macro/tests/template/component-fail.rs
@@ -7,7 +7,7 @@ fn c() -> Template<G> {
     }
 }
 
-fn compile_fail<G: GenericNode>() {
+fn compile_fail<G: Html>() {
     let _: Template<G> = template! { UnknownComponent() };
 
     let _: Template<G> = template! { C };

--- a/packages/sycamore-macro/tests/template/component-pass.rs
+++ b/packages/sycamore-macro/tests/template/component-pass.rs
@@ -7,7 +7,7 @@ pub fn component() -> Template<G> {
     }
 }
 
-fn compile_pass<G: GenericNode>() {
+fn compile_pass<G: Html>() {
     let _: Template<G> = template! { Component() };
 }
 

--- a/packages/sycamore/src/builder/agnostic/mod.rs
+++ b/packages/sycamore/src/builder/agnostic/mod.rs
@@ -1,7 +1,7 @@
 //! The renderer-agnostic API.
 
 use crate::component::Component;
-use crate::generic_node::GenericNode;
+use crate::generic_node::{GenericNode, Html};
 use crate::noderef::NodeRef;
 use crate::template::Template;
 use crate::utils::render;
@@ -51,13 +51,13 @@ where
 /// }
 ///
 /// // Elsewhere in another component.
-/// # fn view<G: GenericNode>() -> Template<G> {
+/// # fn view<G: Html>() -> Template<G> {
 /// component::<_, MyComponent<_>>(())
 /// # }
 /// ```
 pub fn component<G, C>(props: C::Props) -> Template<G>
 where
-    G: GenericNode,
+    G: GenericNode + Html,
     C: Component<G>,
 {
     C::__create_component(props)
@@ -197,7 +197,7 @@ where
     ///     h1().text("My component").build()
     /// }
     ///
-    /// # fn _test<G: GenericNode>() -> Template<G> {
+    /// # fn _test<G: Html>() -> Template<G> {
     /// div().component::<MyComponent<_>>(()).build()
     /// }
     /// ```

--- a/packages/sycamore/src/generic_node.rs
+++ b/packages/sycamore/src/generic_node.rs
@@ -42,6 +42,12 @@ pub type EventHandler = dyn Fn(Event);
 /// [`GenericNode`]s should be cheaply cloneable (usually backed by a [`Rc`](std::rc::Rc) or other
 /// reference counted container) and preserve reference equality.
 pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
+    /// A boolean indicating whether this node is rendered in a browser context.
+    ///
+    /// A value of `false` does not necessarily mean that it is not being rendered in WASM or even
+    /// in the browser. It only means that it does not create DOM nodes.
+    const IS_BROWSER: bool;
+
     /// Create a new element node.
     fn element(tag: &str) -> Self;
 

--- a/packages/sycamore/src/generic_node.rs
+++ b/packages/sycamore/src/generic_node.rs
@@ -123,3 +123,9 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
     /// Create a deep clone of the node.
     fn clone_node(&self) -> Self;
 }
+
+/// Trait that is implemented by all [`GenericNode`] backends that render to HTML.
+pub trait Html: GenericNode {}
+
+impl Html for DomNode {}
+impl Html for SsrNode {}

--- a/packages/sycamore/src/generic_node.rs
+++ b/packages/sycamore/src/generic_node.rs
@@ -126,6 +126,3 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
 
 /// Trait that is implemented by all [`GenericNode`] backends that render to HTML.
 pub trait Html: GenericNode {}
-
-impl Html for DomNode {}
-impl Html for SsrNode {}

--- a/packages/sycamore/src/generic_node.rs
+++ b/packages/sycamore/src/generic_node.rs
@@ -42,12 +42,6 @@ pub type EventHandler = dyn Fn(Event);
 /// [`GenericNode`]s should be cheaply cloneable (usually backed by a [`Rc`](std::rc::Rc) or other
 /// reference counted container) and preserve reference equality.
 pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
-    /// A boolean indicating whether this node is rendered in a browser context.
-    ///
-    /// A value of `false` does not necessarily mean that it is not being rendered in WASM or even
-    /// in the browser. It only means that it does not create DOM nodes.
-    const IS_BROWSER: bool;
-
     /// Create a new element node.
     fn element(tag: &str) -> Self;
 
@@ -129,4 +123,10 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
 }
 
 /// Trait that is implemented by all [`GenericNode`] backends that render to HTML.
-pub trait Html: GenericNode {}
+pub trait Html: GenericNode {
+    /// A boolean indicating whether this node is rendered in a browser context.
+    ///
+    /// A value of `false` does not necessarily mean that it is not being rendered in WASM or even
+    /// in the browser. It only means that it does not create DOM nodes.
+    const IS_BROWSER: bool;
+}

--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::{intern, JsCast};
 use web_sys::{Comment, Element, Node, Text};
 
-use crate::generic_node::{EventHandler, GenericNode};
+use crate::generic_node::{EventHandler, GenericNode, Html};
 use crate::reactive::{create_root, on_cleanup, ReactiveScope};
 use crate::template::Template;
 use crate::utils::render::insert;
@@ -263,6 +263,8 @@ impl GenericNode for DomNode {
         }
     }
 }
+
+impl Html for DomNode {}
 
 /// Render a [`Template`] into the DOM.
 /// Alias for [`render_to`] with `parent` being the `<body>` tag.

--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -131,6 +131,8 @@ fn document() -> web_sys::Document {
 }
 
 impl GenericNode for DomNode {
+    const IS_BROWSER: bool = true;
+
     fn element(tag: &str) -> Self {
         let node = document()
             .create_element(intern(tag))

--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -125,8 +125,6 @@ fn document() -> web_sys::Document {
 }
 
 impl GenericNode for DomNode {
-    const IS_BROWSER: bool = true;
-
     fn element(tag: &str) -> Self {
         let node = document()
             .create_element(intern(tag))
@@ -274,7 +272,9 @@ impl GenericNode for DomNode {
     }
 }
 
-impl Html for DomNode {}
+impl Html for DomNode {
+    const IS_BROWSER: bool = true;
+}
 
 /// Render a [`Template`] into the DOM.
 /// Alias for [`render_to`] with `parent` being the `<body>` tag.

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -119,8 +119,6 @@ impl SsrNode {
 }
 
 impl GenericNode for SsrNode {
-    const IS_BROWSER: bool = false;
-
     fn element(tag: &str) -> Self {
         SsrNode::new(SsrNodeType::Element(RefCell::new(Element {
             name: tag.to_string(),
@@ -328,7 +326,9 @@ impl GenericNode for SsrNode {
     }
 }
 
-impl Html for SsrNode {}
+impl Html for SsrNode {
+    const IS_BROWSER: bool = false;
+}
 
 trait WriteToString {
     fn write_to_string(&self, s: &mut String);

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -118,6 +118,8 @@ impl SsrNode {
 }
 
 impl GenericNode for SsrNode {
+    const IS_BROWSER: bool = false;
+
     fn element(tag: &str) -> Self {
         SsrNode::new(SsrNodeType::Element(RefCell::new(Element {
             name: tag.to_string(),

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -9,7 +9,7 @@ use ahash::AHashMap;
 use once_cell::sync::Lazy;
 use wasm_bindgen::prelude::*;
 
-use crate::generic_node::{EventHandler, GenericNode};
+use crate::generic_node::{EventHandler, GenericNode, Html};
 use crate::reactive::create_root;
 use crate::template::Template;
 
@@ -294,6 +294,8 @@ impl GenericNode for SsrNode {
         Self(Rc::new(inner))
     }
 }
+
+impl Html for SsrNode {}
 
 trait WriteToString {
     fn write_to_string(&self, s: &mut String);

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -50,6 +50,7 @@ pub mod prelude {
     #[cfg(feature = "dom")]
     pub use crate::generic_node::DomNode;
     pub use crate::generic_node::GenericNode;
+    pub use crate::generic_node::Html;
     #[cfg(feature = "ssr")]
     pub use crate::generic_node::SsrNode;
     pub use crate::noderef::NodeRef;

--- a/packages/sycamore/src/portal.rs
+++ b/packages/sycamore/src/portal.rs
@@ -1,6 +1,6 @@
 //! Portal API.
 
-use std::any::{Any, TypeId};
+use std::any::{Any};
 
 use wasm_bindgen::prelude::*;
 
@@ -20,7 +20,7 @@ where
 pub fn portal(props: PortalProps<G>) -> Template<G> {
     let PortalProps { children, selector } = props;
 
-    if TypeId::of::<G>() == TypeId::of::<DomNode>() {
+    if G::IS_BROWSER {
         let window = web_sys::window().unwrap_throw();
         let document = window.document().unwrap_throw();
         let container = document

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -63,7 +63,7 @@ async fn get_sidebar(version: Option<&str>) -> SidebarData {
     }
 }
 
-fn switch<G: GenericNode>(route: StateHandle<Routes>) -> Template<G> {
+fn switch<G: Html>(route: StateHandle<Routes>) -> Template<G> {
     let template = Signal::new(Template::empty());
     let cached_sidebar_data: Signal<Option<(Option<String>, SidebarData)>> = Signal::new(None);
     create_effect(cloned!((template) => move || {


### PR DESCRIPTION
This fixes the ugly hack of using
```rust
if TypeId::of::<G>() == TypeId::of::<DomNode>() { ... }
```
and replaces it with
```rust
if G::IS_BROWSER { ... }
```