### PR TITLE
Add helper macros for common functions that use `cloned!`

### DIFF
--- a/docs/next/advanced/routing.md
+++ b/docs/next/advanced/routing.md
@@ -277,7 +277,7 @@ use sycamore::futures::spawn_local_in_scope;
 template! {
     Router(RouterProps::new(HistoryIntegration::new(), |route: StateHandle<AppRoutes>| {
         let template = Signal::new(Template::empty());
-        create_effect(cloned!((template) => move || {
+        create_effect!(template => move || {
             let route = route.get();
             spawn_local_in_scope(cloned!((template) => async move {
                 let t = match route.as_ref() {
@@ -293,7 +293,7 @@ template! {
                 };
                 template.set(t);
             }));
-        }));
+        });
 
         template! {
             div(class="app") {

--- a/docs/next/basics/control_flow.md
+++ b/docs/next/basics/control_flow.md
@@ -31,7 +31,7 @@ let name = Signal::new(String::new());
 
 template! {
     h1 {
-        (if *create_selector(cloned!((name) => move || !name.get().is_empty())).get() {
+        (if *create_selector!(name => move || !name.get().is_empty()).get() {
             cloned!((name) => template! {
                 span { (name.get()) }
             })

--- a/docs/next/basics/reactivity.md
+++ b/docs/next/basics/reactivity.md
@@ -67,15 +67,17 @@ all its _dependents_, in this case, `state` as it was called inside the closure.
 >
 > This is ultimately just a workaround until something happens in
 > [Rust RFC #2407](https://github.com/rust-lang/rfcs/issues/2407).
+>
+> You can also use `create_effect!` and friends which are wrappers around `cloned!` and their respective functions
 
 ## Memos
 
-We can also easily create a derived state using `create_memo(...)` which is really just an ergonomic
+We can also easily create a derived state using `create_memo(...)` (or `create_memo!`) which is really just an ergonomic
 wrapper around `create_effect`:
 
 ```rust
 let state = Signal::new(0);
-let double = create_memo(cloned!((state) => move || *state.get() * 2));
+let double = create_memo!(state => move || *state.get() * 2);
 
 assert_eq!(*double.get(), 0);
 

--- a/examples/context/src/main.rs
+++ b/examples/context/src/main.rs
@@ -36,9 +36,9 @@ pub fn controls() -> Template<G> {
 fn app() -> Template<G> {
     let counter = Signal::new(0);
 
-    create_effect(cloned!((counter) => move || {
+    create_effect!(counter => move || {
         log::info!("Counter value: {}", *counter.get());
-    }));
+    });
 
     template! {
         ContextProvider(ContextProviderProps {

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -4,9 +4,9 @@ use sycamore::prelude::*;
 fn app() -> Template<G> {
     let counter = Signal::new(0);
 
-    create_effect(cloned!((counter) => move || {
+    create_effect!(counter => move || {
         log::info!("Counter value: {}", *counter.get());
-    }));
+    });
 
     let increment = cloned!((counter) => move |_| counter.set(*counter.get() + 1));
 

--- a/examples/hello/src/main.rs
+++ b/examples/hello/src/main.rs
@@ -9,7 +9,7 @@ fn app() -> Template<G> {
         div {
             h1 {
                 "Hello "
-                (if *create_selector(cloned!((name) => move || !name.get().is_empty())).get() {
+                (if *create_selector!(name => move || !name.get().is_empty()).get() {
                     cloned!((name) => template! {
                         span { (name.get()) }
                     })

--- a/examples/todomvc/src/footer.rs
+++ b/examples/todomvc/src/footer.rs
@@ -11,9 +11,9 @@ pub fn footer(app_state: AppState) -> Template<G> {
         }
     });
 
-    let has_completed_todos = create_selector(cloned!((app_state) => move || {
+    let has_completed_todos = create_selector!(app_state => move || {
         app_state.todos_left() < app_state.todos.get().len()
-    }));
+    });
 
     let app_state2 = app_state.clone();
     let app_state3 = app_state.clone();

--- a/examples/todomvc/src/item.rs
+++ b/examples/todomvc/src/item.rs
@@ -14,7 +14,7 @@ pub fn item(props: ItemProps) -> Template<G> {
     let ItemProps { todo, app_state } = props;
 
     let title = cloned!((todo) => move || todo.get().title.clone());
-    let completed = create_selector(cloned!((todo) => move || todo.get().completed));
+    let completed = create_selector!(todo => move || todo.get().completed);
     let id = todo.get().id;
 
     let editing = Signal::new(false);
@@ -74,10 +74,10 @@ pub fn item(props: ItemProps) -> Template<G> {
     // We need a separate signal for checked because clicking the checkbox will detach the binding
     // between the attribute and the view.
     let checked = Signal::new(false);
-    create_effect(cloned!((completed, checked) => move || {
+    create_effect!(completed, checked => move || {
         // Calling checked.set will also update the `checked` property on the input element.
         checked.set(*completed.get())
-    }));
+    });
 
     let class = cloned!((completed, editing) => move || {
         format!("{} {}",

--- a/examples/todomvc/src/list.rs
+++ b/examples/todomvc/src/list.rs
@@ -4,25 +4,25 @@ use crate::{AppState, Filter};
 
 #[component(List<G>)]
 pub fn list(app_state: AppState) -> Template<G> {
-    let todos_left = create_selector(cloned!((app_state) => move || {
+    let todos_left = create_selector!(app_state => move || {
         app_state.todos_left()
-    }));
+    });
 
-    let filtered_todos = create_memo(cloned!((app_state) => move || {
+    let filtered_todos = create_memo!(app_state => move || {
         app_state.todos.get().iter().filter(|todo| match *app_state.filter.get() {
             Filter::All => true,
             Filter::Active => !todo.get().completed,
             Filter::Completed => todo.get().completed,
         }).cloned().collect::<Vec<_>>()
-    }));
+    });
 
     // We need a separate signal for checked because clicking the checkbox will detach the binding
     // between the attribute and the view.
     let checked = Signal::new(false);
-    create_effect(cloned!((checked) => move || {
+    create_effect!(checked => move || {
         // Calling checked.set will also update the `checked` property on the input element.
         checked.set(*todos_left.get() == 0)
-    }));
+    });
 
     template! {
         section(class="main") {

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -149,16 +149,15 @@ fn app() -> Template<G> {
         filter: Signal::new(Filter::get_filter_from_hash()),
     };
 
-    create_effect(cloned!((local_storage, app_state) => move || {
+    create_effect!(local_storage, app_state => move || {
         for todo in app_state.todos.get().iter() {
             todo.get(); // subscribe to changes in all todos
         }
 
         local_storage.set_item(KEY, &serde_json::to_string(app_state.todos.get().as_ref()).unwrap()).unwrap();
-    }));
+    });
 
-    let todos_is_empty =
-        create_selector(cloned!((app_state) => move || app_state.todos.get().len() == 0));
+    let todos_is_empty = create_selector!(app_state => move || app_state.todos.get().len() == 0);
 
     template! {
         div(class="todomvc-wrapper") {

--- a/packages/sycamore-reactive/src/lib.rs
+++ b/packages/sycamore-reactive/src/lib.rs
@@ -128,7 +128,7 @@ macro_rules! create_cloned_wrapper {
     }
 }
 
-create_cloned_wrapper!($ create_effect, create_memo, create_root, create_selector);
+create_cloned_wrapper!($ create_effect, create_memo, create_root, create_selector, on_cleanup, untrack);
 
 #[cfg(test)]
 mod tests {

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -219,7 +219,7 @@ where
     });
 
     let route_signal: Rc<RefCell<Option<Signal<R>>>> = Rc::new(RefCell::new(None));
-    create_effect(cloned!((route_signal) => move || {
+    create_effect!(route_signal => move || {
         let path = path.get();
         let route = R::match_route(path.iter().map(|s| s.as_str()).collect::<Vec<_>>().as_slice());
         if route_signal.borrow().is_some() {
@@ -227,7 +227,7 @@ where
         } else {
             *route_signal.borrow_mut() = Some(Signal::new(route));
         }
-    }));
+    });
     // Delegate click events from child <a> tags.
     let tmp = render.take().unwrap_throw()(route_signal.borrow().as_ref().unwrap_throw().handle());
     if let Some(node) = tmp.as_node() {

--- a/packages/sycamore/benches/reactivity.rs
+++ b/packages/sycamore/benches/reactivity.rs
@@ -16,10 +16,10 @@ pub fn bench(c: &mut Criterion) {
     c.bench_function("reactivity_effects", |b| {
         b.iter(|| {
             let state = Signal::new(black_box(0));
-            create_effect(cloned!((state) => move || {
+            create_effect!(state => move || {
                 let double = *state.get() * 2;
                 black_box(double);
-            }));
+            });
 
             for _i in 0..1000 {
                 state.set(*state.get() + 1);

--- a/packages/sycamore/tests/web/cleanup.rs
+++ b/packages/sycamore/tests/web/cleanup.rs
@@ -34,10 +34,10 @@ pub fn test_cleanup_in_root() {
 pub fn test_cleanup_in_effect() {
     let trigger = Signal::new(());
 
-    create_effect(cloned!((trigger) => move || {
+    create_effect!(trigger => move || {
         trigger.get();
         on_cleanup(on_cleanup_callback);
-    }));
+    });
 
     assert_cleanup_called(|| {
         trigger.set(());

--- a/packages/sycamore/tests/web/portal.rs
+++ b/packages/sycamore/tests/web/portal.rs
@@ -21,14 +21,14 @@ fn test_portal() {
 
     sycamore::render_to(
         cloned!((portal, portal_root) => move || {
-            let root = create_root(cloned!((portal) => move || {
+            let root = create_root!(portal => move || {
                 portal.set(Some(template! {
                     Portal(PortalProps {
                         children: template! { "Hello World!" },
                         selector: "#portal-target",
                     })
                 }));
-            }));
+            });
             *portal_root.borrow_mut() = Some(root);
             template! {
                 (portal.get().as_ref().clone().unwrap_or_default())

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -66,7 +66,7 @@ async fn get_sidebar(version: Option<&str>) -> SidebarData {
 fn switch<G: GenericNode>(route: StateHandle<Routes>) -> Template<G> {
     let template = Signal::new(Template::empty());
     let cached_sidebar_data: Signal<Option<(Option<String>, SidebarData)>> = Signal::new(None);
-    create_effect(cloned!((template) => move || {
+    create_effect!(template => move || {
         let route = route.get();
         spawn_local_in_scope(cloned!((template, cached_sidebar_data) => async move {
             let t = match route.as_ref() {
@@ -130,7 +130,7 @@ fn switch<G: GenericNode>(route: StateHandle<Routes>) -> Template<G> {
             };
             template.set(t);
         }));
-    }));
+    });
 
     template! {
         div(class="pt-12 text-black dark:text-gray-200 bg-white dark:bg-gray-800 \
@@ -181,11 +181,11 @@ fn main() {
     };
     let dark_mode = DarkMode(Signal::new(dark_mode));
 
-    create_effect(cloned!((dark_mode) => move || {
+    create_effect!(dark_mode => move || {
         if let Some(local_storage) = &local_storage {
             local_storage.set_item("dark_mode", &dark_mode.0.get().to_string()).unwrap();
         }
-    }));
+    });
 
     sycamore::render(|| {
         template! {


### PR DESCRIPTION
This commit adds a macro for generating wrappers around functions that
accept a closure and makes it easier to pass cloned variables.

This commit also uses said macro to generate wrappers for the following
functions:

- `create_effect`
- `create_memo`
- `create_selector`
- `create_root`