### PR TITLE
Make `wasm-bindgen-interning` a feature

### DIFF
--- a/packages/sycamore/Cargo.toml
+++ b/packages/sycamore/Cargo.toml
@@ -19,11 +19,11 @@ html-escape = { version = "0.2.9", optional = true }
 indexmap = { version = "1.7.0", features = ["std"] }
 js-sys = "0.3.55"
 once_cell = { version = "1.8.0", optional = true }
-paste = "1.0"
+paste = "1.0.5"
 smallvec = "1.6.1"
 sycamore-macro = { path = "../sycamore-macro", version = "=0.6.3" }
 sycamore-reactive = { path = "../sycamore-reactive", version = "=0.6.3" }
-wasm-bindgen = { version = "0.2.78", features = ["enable-interning"] }
+wasm-bindgen = "0.2.78"
 wasm-bindgen-futures = { version = "0.4.28", optional = true }
 
 [dependencies.lexical]
@@ -54,13 +54,14 @@ criterion = { version = "0.3.5", features = ["html_reports"] }
 wasm-bindgen-test = "0.3.28"
 
 [features]
-default = ["dom"]
+default = ["dom", "wasm-bindgen-interning"]
 dom = []
+experimental-builder-agnostic = []
+experimental-builder-html = ["experimental-builder-agnostic"]
 futures = ["wasm-bindgen-futures"]
 ssr = ["html-escape", "once_cell"]
 serde = ["sycamore-reactive/serde"]
-experimental-builder-agnostic = []
-experimental-builder-html = ["experimental-builder-agnostic"]
+wasm-bindgen-interning = ["wasm-bindgen/enable-interning"]
 
 [[bench]]
 harness = false

--- a/packages/sycamore/src/futures.rs
+++ b/packages/sycamore/src/futures.rs
@@ -1,3 +1,5 @@
+//! Utilities for working with [`Future`]s and `async/await` code.
+
 use std::future::Future;
 
 use sycamore_reactive::current_scope;

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -5,15 +5,21 @@
 //! This is the API docs for sycamore. If you are looking for the usage docs, checkout the
 //! [Sycamore Book](https://sycamore-rs.netlify.app/docs/getting_started/installation).
 //!
-//! ## Features
+//! ## Feature Flags
 //! - `dom` (_default_) - Enables rendering templates to DOM nodes. Only useful on
 //!   `wasm32-unknown-unknown` target.
+//! - `experimental-builder-agnostic` - Enables the agnostic backend builder API.
+//! - `experimental-builder-html` - Enables the HTML specific backend builder API. Also enables
+//!   `experimental-builder-agnostic`.
 //! - `futures` - Enables wrappers around `wasm-bindgen-futures` to make it easier to extend a
 //!   reactive scope into an `async` function.
 //! - `ssr` - Enables rendering templates to static strings (useful for Server Side Rendering /
 //!   Pre-rendering).
 //! - `serde` - Enables serializing and deserializing `Signal`s and other wrapper types using
 //!   `serde`.
+//! - `wasm-bindgen-interning` (_default_) - Enables interning for `wasm-bindgen` strings. This
+//!   improves performance at a slight cost in binary size. If you want to minimize the size of the
+//!   result `.wasm` binary, you might want to disable this.
 
 #![warn(clippy::clone_on_ref_ptr)]
 #![warn(clippy::rc_buffer)]

--- a/packages/sycamore/src/portal.rs
+++ b/packages/sycamore/src/portal.rs
@@ -1,6 +1,6 @@
 //! Portal API.
 
-use std::any::{Any};
+use std::any::Any;
 
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
The `wasm-bindgen-interning` feature in turn enables the `wasm-bindgen/enable-interning` feature.
This feature is on by default.