### PR TITLE
Make `GenericNode` generic over the event type

### DIFF
--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-use sycamore::generic_node::EventHandler;
 use sycamore::prelude::*;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
@@ -21,7 +20,7 @@ pub trait Integration {
 
     /// Get the click handler that is run when links are clicked.
 
-    fn click_handler(&self) -> Box<EventHandler>;
+    fn click_handler(&self) -> Box<dyn Fn(web_sys::Event)>;
 }
 
 thread_local! {
@@ -63,7 +62,7 @@ impl Integration for HistoryIntegration {
         closure.forget();
     }
 
-    fn click_handler(&self) -> Box<EventHandler> {
+    fn click_handler(&self) -> Box<dyn Fn(web_sys::Event)> {
         Box::new(|ev| {
             if let Some(a) = ev
                 .target()

--- a/packages/sycamore/src/builder/agnostic/mod.rs
+++ b/packages/sycamore/src/builder/agnostic/mod.rs
@@ -543,7 +543,7 @@ where
     /// ```
     /// # use sycamore::prelude::*;
     /// # use sycamore::builder::html::*;
-    /// # fn _test<G: GenericNode>() -> Template<G> {
+    /// # fn _test<G: Html>() -> Template<G> {
     /// let value = Signal::new(String::new());
     ///
     /// input()
@@ -581,7 +581,7 @@ where
     /// ```
     /// # use sycamore::prelude::*;
     /// # use sycamore::builder::html::*;
-    /// # fn _test<G: GenericNode>() -> Template<G> {
+    /// # fn _test<G: Html>() -> Template<G> {
     /// let checked = Signal::new(false);
     ///
     /// input()

--- a/packages/sycamore/src/builder/agnostic/mod.rs
+++ b/packages/sycamore/src/builder/agnostic/mod.rs
@@ -484,13 +484,57 @@ where
     pub fn on<E, H>(&self, event: E, handler: H) -> &Self
     where
         E: AsRef<str>,
-        H: Fn(web_sys::Event) + 'static,
+        H: Fn(G::EventType) + 'static,
     {
         self.element.event(event.as_ref(), Box::new(handler));
 
         self
     }
 
+    /// Get a hold of the raw element by using a [`NodeRef`].
+    ///
+    /// # Example
+    /// ```
+    /// # use sycamore::prelude::*;
+    /// # use sycamore::builder::html::*;
+    /// # fn _test<G: GenericNode>() -> Template<G> {
+    /// let node_ref = NodeRef::new();
+    ///
+    /// input()
+    ///     .bind_ref(node_ref.clone())
+    ///     .build()
+    /// # }
+    /// ```
+    pub fn bind_ref(&self, node_ref: NodeRef<G>) -> &Self {
+        node_ref.set(self.element.clone());
+
+        self
+    }
+
+    /// Builds the [`NodeBuilder`] and returns a [`Template`].
+    ///
+    /// This is the function that should be called at the end of the node
+    /// building chain.
+    ///
+    /// # Example
+    /// ```
+    /// # use sycamore::prelude::*;
+    /// # use sycamore::builder::html::*;
+    /// # fn _test<G: GenericNode>() -> Template<G> {
+    /// input()
+    ///     /* builder stuff */
+    ///     .build()
+    /// # }
+    /// ```
+    pub fn build(&self) -> Template<G> {
+        Template::new_node(self.element.to_owned())
+    }
+}
+
+impl<G> NodeBuilder<G>
+where
+    G: GenericNode + Html,
+{
     /// Binds `sub` to the `value` property of the node.
     ///
     /// `sub` will be automatically updated when the value is updated.
@@ -569,44 +613,5 @@ where
                 );
             }
         })
-    }
-
-    /// Get a hold of the [`element`](::web_sys::Node) by using a [`NodeRef`].
-    ///
-    /// # Example
-    /// ```
-    /// # use sycamore::prelude::*;
-    /// # use sycamore::builder::html::*;
-    /// # fn _test<G: GenericNode>() -> Template<G> {
-    /// let node_ref = NodeRef::new();
-    ///
-    /// input()
-    ///     .bind_ref(node_ref.clone())
-    ///     .build()
-    /// # }
-    /// ```
-    pub fn bind_ref(&self, node_ref: NodeRef<G>) -> &Self {
-        node_ref.set(self.element.clone());
-
-        self
-    }
-
-    /// Builds the [`NodeBuilder`] and returns a [`Template`].
-    ///
-    /// This is the function that should be called at the end of the node
-    /// building chain.
-    ///
-    /// # Example
-    /// ```
-    /// # use sycamore::prelude::*;
-    /// # use sycamore::builder::html::*;
-    /// # fn _test<G: GenericNode>() -> Template<G> {
-    /// input()
-    ///     /* builder stuff */
-    ///     .build()
-    /// # }
-    /// ```
-    pub fn build(&self) -> Template<G> {
-        Template::new_node(self.element.to_owned())
     }
 }

--- a/packages/sycamore/src/generic_node.rs
+++ b/packages/sycamore/src/generic_node.rs
@@ -16,9 +16,6 @@ pub use dom_node::*;
 #[cfg(feature = "ssr")]
 pub use ssr_node::*;
 
-/// Type of event handlers.
-pub type EventHandler = dyn Fn(Event);
-
 /// Abstraction over a rendering backend.
 ///
 /// You would probably use this trait as a trait bound when you want to accept any rendering
@@ -42,6 +39,9 @@ pub type EventHandler = dyn Fn(Event);
 /// [`GenericNode`]s should be cheaply cloneable (usually backed by a [`Rc`](std::rc::Rc) or other
 /// reference counted container) and preserve reference equality.
 pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
+    /// The type of the event that is passed to the event handler.
+    type EventType;
+
     /// Create a new element node.
     fn element(tag: &str) -> Self;
 
@@ -107,7 +107,7 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
     fn remove_self(&self);
 
     /// Add a [`EventHandler`] to the event `name`.
-    fn event(&self, name: &str, handler: Box<EventHandler>);
+    fn event(&self, name: &str, handler: Box<dyn Fn(Self::EventType)>);
 
     /// Update inner text of the node. If the node has elements, all the elements are replaced with
     /// a new text node.
@@ -123,7 +123,7 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
 }
 
 /// Trait that is implemented by all [`GenericNode`] backends that render to HTML.
-pub trait Html: GenericNode {
+pub trait Html: GenericNode<EventType = Event> {
     /// A boolean indicating whether this node is rendered in a browser context.
     ///
     /// A value of `false` does not necessarily mean that it is not being rendered in WASM or even

--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -8,7 +8,7 @@ use wasm_bindgen::prelude::*;
 use wasm_bindgen::{intern, JsCast};
 use web_sys::{Comment, Element, Node, Text};
 
-use crate::generic_node::{EventHandler, GenericNode, Html};
+use crate::generic_node::{GenericNode, Html};
 use crate::reactive::{create_root, on_cleanup, ReactiveScope};
 use crate::template::Template;
 use crate::utils::render::insert;
@@ -125,6 +125,8 @@ fn document() -> web_sys::Document {
 }
 
 impl GenericNode for DomNode {
+    type EventType = web_sys::Event;
+
     fn element(tag: &str) -> Self {
         let node = document()
             .create_element(intern(tag))
@@ -245,7 +247,7 @@ impl GenericNode for DomNode {
         self.node.unchecked_ref::<Element>().remove();
     }
 
-    fn event(&self, name: &str, handler: Box<EventHandler>) {
+    fn event(&self, name: &str, handler: Box<dyn Fn(Self::EventType)>) {
         let closure = Closure::wrap(handler);
         self.node
             .add_event_listener_with_callback(intern(name), closure.as_ref().unchecked_ref())

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -10,7 +10,7 @@ use ahash::AHashMap;
 use once_cell::sync::Lazy;
 use wasm_bindgen::prelude::*;
 
-use crate::generic_node::{EventHandler, GenericNode, Html};
+use crate::generic_node::{GenericNode, Html};
 use crate::reactive::create_root;
 use crate::template::Template;
 
@@ -119,6 +119,12 @@ impl SsrNode {
 }
 
 impl GenericNode for SsrNode {
+    /// Although [`SsrNode`] is intended to be used on the server-side instead of in the browser,
+    /// the event type is still [`web_sys::Event`] because it must support the same API as
+    /// [`DomNode`](super::DomNode). Since event handlers will never be called on the server side
+    /// anyways, it's okay to do this.
+    type EventType = web_sys::Event;
+
     fn element(tag: &str) -> Self {
         SsrNode::new(SsrNodeType::Element(RefCell::new(Element {
             name: tag.to_string(),
@@ -293,7 +299,7 @@ impl GenericNode for SsrNode {
             .remove_child(self);
     }
 
-    fn event(&self, _name: &str, _handler: Box<EventHandler>) {
+    fn event(&self, _name: &str, _handler: Box<dyn Fn(Self::EventType)>) {
         // Noop. Events are attached on client side.
     }
 

--- a/packages/sycamore/src/portal.rs
+++ b/packages/sycamore/src/portal.rs
@@ -1,6 +1,6 @@
 //! Portal API.
 
-use std::any::{Any};
+use std::any::Any;
 
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
This allows creating rendering backends that do not use `web_sys::Event` in event handlers