### PR TITLE
render_temporarily_to() helper

### DIFF
--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -289,6 +289,34 @@ pub fn render(template: impl FnOnce() -> View<DomNode>) {
     render_to(template, &document.body().unwrap_throw());
 }
 
+/// Render a [`View`] under a `parent` node, in a way that can be cleaned up.
+/// This function is intended to be used for injecting an ephemeral sycamore view into a non-sycamore app
+/// (for example, a file upload modal where you want to cancel the upload if the modal is closed).
+/// You should only use this function while refactoring your app, and you should aim to have a single
+/// call to [`render`] or [`render_to`] at the top level of your app long-term.
+/// For rendering a view that will never be unmounted from the dom, use [`render_to`] instead.
+/// For rendering under the `<body>` tag, use [`render`] instead.
+///
+/// _This API requires the following crate features to be activated: `dom`_
+#[must_use = "please hold onto the ReactiveScope until you want to clean things up, or use render_to() instead"]
+pub fn render_temporarily_to(
+    template: impl FnOnce() -> View<DomNode>,
+    parent: &Node,
+) -> ReactiveScope {
+    create_root(|| {
+        insert(
+            &DomNode {
+                id: Default::default(),
+                node: parent.clone(),
+            },
+            template(),
+            None,
+            None,
+            false,
+        );
+    })
+}
+
 /// Render a [`View`] under a `parent` node.
 /// For rendering under the `<body>` tag, use [`render`] instead.
 ///

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -51,9 +51,7 @@ pub mod futures;
 extern crate self as sycamore;
 
 #[cfg(feature = "dom")]
-pub use crate::generic_node::{
-    hydrate, hydrate_to, render, render_temporarily_to, render_to, DomNode,
-};
+pub use crate::generic_node::{hydrate, hydrate_to, render, render_get_scope, render_to, DomNode};
 #[cfg(feature = "ssr")]
 pub use crate::generic_node::{render_to_string, SsrNode};
 

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -51,7 +51,9 @@ pub mod futures;
 extern crate self as sycamore;
 
 #[cfg(feature = "dom")]
-pub use crate::generic_node::{hydrate, hydrate_to, render, render_to, DomNode};
+pub use crate::generic_node::{
+    hydrate, hydrate_to, render, render_temporarily_to, render_to, DomNode,
+};
 #[cfg(feature = "ssr")]
 pub use crate::generic_node::{render_to_string, SsrNode};
 


### PR DESCRIPTION
As I mentioned in https://discord.com/channels/820400041332179004/821489793258487839/912364912624418846 I was having problems with things not getting dropped when gradually converting an existing app to use sycamore.

This function is intended to be used for injecting an ephemeral sycamore view into a non-sycamore app
(for example, a file upload modal where you want to cancel the upload if the modal is closed).
You should only use this function while refactoring your app, and you should aim to have a single
call to [`render`] or [`render_to`] at the top level of your app long-term.

Using this function did solve my problems.