### PR TITLE
Fix parenthesizing of expressions in `view!` interpolation syntax

### DIFF
--- a/packages/sycamore-macro/Cargo.toml
+++ b/packages/sycamore-macro/Cargo.toml
@@ -23,7 +23,7 @@ quote = "1.0.10"
 syn = "1.0.81"
 
 [dev-dependencies]
-sycamore = { path = "../sycamore" }
+sycamore = { path = "../sycamore", features = ["experimental-hydrate"] }
 trybuild = "1.0.52"
 
 [features]

--- a/packages/sycamore-macro/src/view/element.rs
+++ b/packages/sycamore-macro/src/view/element.rs
@@ -111,7 +111,7 @@ impl ToTokens for Element {
                         quote_spanned! { splice.span()=>
                             ::sycamore::utils::render::insert(
                                 &__el,
-                                ::sycamore::view::IntoView::create(&#splice),
+                                ::sycamore::view::IntoView::create(&(#splice)),
                                 None, None, #multi
                             );
                         }
@@ -215,7 +215,7 @@ impl ToTokens for Element {
                                         ::sycamore::utils::render::insert(
                                             &__el,
                                             ::sycamore::view::View::new_dyn(move ||
-                                                ::sycamore::view::IntoView::create(&#splice)
+                                                ::sycamore::view::IntoView::create(&(#splice))
                                             ),
                                             #initial, Some(&__end_marker), #multi
                                         );
@@ -225,7 +225,7 @@ impl ToTokens for Element {
                                         ::sycamore::utils::render::insert(
                                             &__el,
                                             ::sycamore::view::View::new_dyn(move ||
-                                                ::sycamore::view::IntoView::create(&#splice)
+                                                ::sycamore::view::IntoView::create(&(#splice))
                                             ),
                                             #initial, __marker, #multi
                                         );
@@ -248,7 +248,7 @@ impl ToTokens for Element {
                                     ::sycamore::utils::render::insert(
                                         &__el,
                                         ::sycamore::view::View::new_dyn(move ||
-                                            ::sycamore::view::IntoView::create(&#splice)
+                                            ::sycamore::view::IntoView::create(&(#splice))
                                         ),
                                         #initial, __marker, #multi
                                     );

--- a/packages/sycamore-macro/tests/view/element-pass.rs
+++ b/packages/sycamore-macro/tests/view/element-pass.rs
@@ -14,6 +14,9 @@ fn compile_pass<G: GenericNode>() {
     let _: View<G> = view! { button(class="my-btn", aria-hidden="true") };
 
     let _: View<G> = view! { p(dangerously_set_inner_html="<span>Test</span>") };
+
+    // view! should correctly parenthesize the (1 + 2) when borrowing.
+    let _: View<G> = view! { p { (1 + 2) } };
 }
 
 fn main() {}


### PR DESCRIPTION
Fixes #262 

Adds an extra `(...)` around `#splice` in `packages/sycamore-macro/src/view/element.rs` to make sure whole expression is borrowed.