### PR TITLE
Hack to fix duplicate text when hydrating

### DIFF
--- a/packages/sycamore/src/utils/render.rs
+++ b/packages/sycamore/src/utils/render.rs
@@ -52,6 +52,12 @@ fn insert_expression<G: GenericNode>(
         ViewType::Node(node) => {
             if let Some(current) = current {
                 clean_children(parent, current.flatten(), marker, Some(node), multi);
+            } else if !multi && cfg!(feature = "experimental-hydrate") {
+                // FIXME: This is an extremely ugly hack to get around the fact that current is None
+                // for text nodes when G is HydrateNode. This will cause the text node to be
+                // inserted twice when hydrating.
+                parent.update_inner_text("");
+                parent.insert_child_before(node, None);
             } else {
                 parent.insert_child_before(node, marker);
             }

--- a/packages/sycamore/tests/web/hydrate.rs
+++ b/packages/sycamore/tests/web/hydrate.rs
@@ -130,6 +130,15 @@ mod dynamic {
 
         sycamore::hydrate_to(cloned!(state => move || v(state.handle())), &c);
 
+        assert_eq!(
+            c.query_selector("p")
+                .unwrap()
+                .unwrap()
+                .text_content()
+                .unwrap(),
+            "0"
+        );
+
         // Reactivity should work normally.
         state.set(1);
         assert_eq!(


### PR DESCRIPTION
This fixes a bug where dynamic text nodes are the single child of parent would be inserted twice when hydrating on the client side.

Fixes #319 