### PR TITLE
Fix spellcheck and translate attributes

### DIFF
--- a/packages/sycamore-macro/src/view/attributes.rs
+++ b/packages/sycamore-macro/src/view/attributes.rs
@@ -47,8 +47,6 @@ static BOOLEAN_ATTRIBUTES_SET: Lazy<HashSet<&'static str>> = Lazy::new(|| {
         "seamless",
         "selected",
         "sortable",
-        "spellcheck",
-        "translate",
     ]
     .into_iter()
     .collect()


### PR DESCRIPTION
It needs to be possible to disable spellcheck explicitly: `<textarea spellcheck="false">`: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck

`translate` is actually a `yes` `no` property: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate