### PR TITLE
Create a new nested scope if `ctx` is used within a dyn fragment

### DIFF
--- a/packages/sycamore-macro/src/view/ir.rs
+++ b/packages/sycamore-macro/src/view/ir.rs
@@ -164,3 +164,25 @@ impl Dyn {
         false
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use super::*;
+
+    #[test]
+    fn needs_ctx_if_ctx_ident_inside_expr() {
+        let ts: Dyn = parse_quote! {
+            (ctx.create_signal(0))
+        };
+        assert!(ts.needs_ctx("ctx"));
+        assert!(!ts.needs_ctx("not_ctx"));
+
+        let not_ctx: Dyn = parse_quote! {
+            (123)
+        };
+        assert!(!ts.needs_ctx("ctx"));
+        assert!(!ts.needs_ctx("not_ctx"));
+    }
+}

--- a/packages/sycamore-macro/src/view/ir.rs
+++ b/packages/sycamore-macro/src/view/ir.rs
@@ -3,6 +3,8 @@
 use std::collections::HashSet;
 
 use once_cell::sync::Lazy;
+use proc_macro2::TokenTree;
+use quote::ToTokens;
 use syn::punctuated::Punctuated;
 use syn::{Expr, Ident, LitStr, Path, Token};
 
@@ -146,4 +148,19 @@ pub struct Text {
 
 pub struct Dyn {
     pub value: Expr,
+}
+
+impl Dyn {
+    /// Returns `true` if the wrapped [`Expr`] has the identifier `ctx` somewhere.
+    pub fn needs_ctx(&self, ctx: &str) -> bool {
+        let ts = self.value.to_token_stream();
+        for t in ts {
+            if let TokenTree::Ident(id) = t {
+                if id == ctx {
+                    return true;
+                }
+            }
+        }
+        false
+    }
 }

--- a/packages/sycamore-macro/src/view/ir.rs
+++ b/packages/sycamore-macro/src/view/ir.rs
@@ -182,7 +182,7 @@ mod tests {
         let not_ctx: Dyn = parse_quote! {
             (123)
         };
-        assert!(!ts.needs_ctx("ctx"));
-        assert!(!ts.needs_ctx("not_ctx"));
+        assert!(!not_ctx.needs_ctx("ctx"));
+        assert!(!not_ctx.needs_ctx("not_ctx"));
     }
 }

--- a/packages/sycamore-macro/src/view/mod.rs
+++ b/packages/sycamore-macro/src/view/mod.rs
@@ -7,9 +7,9 @@ pub mod ir;
 pub mod parse;
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::parse::{Parse, ParseStream};
-use syn::{Expr, Result, Token};
+use syn::{parse_quote, Expr, Result, Token};
 
 use self::codegen::Codegen;
 use self::ir::*;
@@ -31,11 +31,12 @@ impl<T: Parse> Parse for WithCtxArg<T> {
 pub fn view_impl(view_root: WithCtxArg<ViewRoot>) -> TokenStream {
     let ctx = view_root.ctx;
     let codegen_state = Codegen {
-        ctx: format_ident!("__ctx"),
+        ctx: parse_quote!(#ctx),
     };
     let quoted = codegen_state.view_root(&view_root.rest);
     quote! {{
-        let __ctx: ::sycamore::reactive::ScopeRef = &#ctx; // Make sure that ctx is used.
+        #[allow(unused_variables)]
+        let #ctx: ::sycamore::reactive::ScopeRef = &#ctx; // Make sure that ctx is used.
         #quoted
     }}
 }
@@ -43,11 +44,12 @@ pub fn view_impl(view_root: WithCtxArg<ViewRoot>) -> TokenStream {
 pub fn node_impl(elem: WithCtxArg<Element>) -> TokenStream {
     let ctx = elem.ctx;
     let codegen_state = Codegen {
-        ctx: format_ident!("__ctx"),
+        ctx: parse_quote!(#ctx),
     };
     let quoted = codegen_state.element(&elem.rest);
     quote! {{
-        let __ctx: ::sycamore::reactive::ScopeRef = &#ctx; // Make sure that ctx is used.
+        #[allow(unused_variables)]
+        let #ctx: ::sycamore::reactive::ScopeRef = &#ctx; // Make sure that ctx is used.
         #quoted
     }}
 }

--- a/packages/sycamore-reactive/src/context.rs
+++ b/packages/sycamore-reactive/src/context.rs
@@ -117,4 +117,14 @@ mod tests {
             });
         });
     }
+
+    #[test]
+    #[should_panic = "existing context with type exists already"]
+    fn existing_context_with_same_type_should_panic() {
+        create_scope_immediate(|ctx| {
+            ctx.provide_context(0i32);
+            ctx.provide_context(0i32);
+            //                  ^^^^ -> has type `i32` and therefore should panic
+        });
+    }
 }

--- a/packages/sycamore-reactive/src/context.rs
+++ b/packages/sycamore-reactive/src/context.rs
@@ -119,6 +119,8 @@ mod tests {
     }
 
     #[test]
+    // Do not run under miri as there is a memory leak false positive.
+    #[cfg_attr(miri, ignore)]
     #[should_panic = "existing context with type exists already"]
     fn existing_context_with_same_type_should_panic() {
         create_scope_immediate(|ctx| {

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -439,6 +439,7 @@ impl WriteToString for RawText {
 /// for rendering to a string on the server side.
 ///
 /// _This API requires the following crate features to be activated: `ssr`_
+#[must_use]
 pub fn render_to_string(view: impl FnOnce(ScopeRef<'_>) -> View<SsrNode>) -> String {
     let mut ret = String::new();
     create_scope_immediate(|ctx| {

--- a/packages/sycamore/tests/ssr/main.rs
+++ b/packages/sycamore/tests/ssr/main.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 use sycamore::prelude::*;
 
 #[test]
@@ -110,5 +112,23 @@ fn bind() {
         };
         let actual = sycamore::render_to_string(|_| node);
         assert_eq!(actual, "<input/>");
+    });
+}
+
+#[test]
+fn using_ctx_in_dyn_node_creates_nested_scope() {
+    let _ = sycamore::render_to_string(|ctx| {
+        let outer_depth = ctx.scope_depth();
+        let inner_depth = ctx.create_ref(Cell::new(0));
+        let node = view! { ctx,
+            p {
+                ({
+                    inner_depth.set(ctx.scope_depth());
+                    view! { ctx, }
+                })
+            }
+        };
+        assert_eq!(inner_depth.get(), outer_depth + 1);
+        node
     });
 }

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -17,9 +17,6 @@ sycamore = { path = "../packages/sycamore", features = ["suspense"] }
 sycamore-router = { path = "../packages/sycamore-router" }
 wasm-bindgen = "0.2.79"
 
-[dev-dependencies]
-docs = { path = "../docs" }
-
 [dependencies.web-sys]
 features = ["MediaQueryList", "Storage", "Window"]
 version = "0.3.56"


### PR DESCRIPTION
If the identifier `ctx` is used inside a dynamic expression inside the `view!` macro, a new scoped effect will be automatically created instead. This prevents memory leaks when the effect reruns.