### PR TITLE
port builder example to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "examples/hydrate",
   "examples/iteration",
   "examples/js-framework-benchmark",
+  "examples/hello-builder",
   "examples/hello-world",
   "examples/higher-order-components",
   "examples/motion",
@@ -29,5 +30,5 @@ members = [
   "website",
 
   # Tools
-  "packages/tools/bench-diff"
+  "packages/tools/bench-diff",
 ]

--- a/examples/hello-builder/Cargo.toml
+++ b/examples/hello-builder/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+authors = ["Luke Chu <37006668+lukechu10@users.noreply.github.com>"]
+edition = "2018"
+name = "hello-builder"
+publish = false
+version = "0.1.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+console_error_panic_hook = "0.1.7"
+console_log = "0.2.0"
+log = "0.4.14"
+sycamore = {path = "../../packages/sycamore", features=["experimental-builder-html"]}
+wasm-bindgen = "0.2.78"

--- a/examples/hello-builder/Cargo.toml
+++ b/examples/hello-builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 authors = ["Luke Chu <37006668+lukechu10@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 name = "hello-builder"
 publish = false
 version = "0.1.0"
@@ -11,5 +11,5 @@ version = "0.1.0"
 console_error_panic_hook = "0.1.7"
 console_log = "0.2.0"
 log = "0.4.14"
-sycamore = {path = "../../packages/sycamore", features=["experimental-builder-html"]}
+sycamore = { path = "../../packages/sycamore", features = ["experimental-builder-html"] }
 wasm-bindgen = "0.2.78"

--- a/examples/hello-builder/index.html
+++ b/examples/hello-builder/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Hello World!</title>
+
+    <style>
+      body {
+        font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+      }
+    </style>
+  </head>
+  <body></body>
+</html>

--- a/examples/hello-builder/src/main.rs
+++ b/examples/hello-builder/src/main.rs
@@ -19,7 +19,7 @@ fn App<G: Html>(ctx: ScopeRef) -> View<G> {
                 .text("!")
                 .build(),
         )
-        .child(input(ctx).bind_value(&name).build())
+        .child(input(ctx).bind_value(name).build())
         .build()
 }
 

--- a/examples/hello-builder/src/main.rs
+++ b/examples/hello-builder/src/main.rs
@@ -1,26 +1,25 @@
 use sycamore::builder::html::*;
 use sycamore::prelude::*;
 
-#[component(App<G>)]
-fn app() -> View<G> {
-    let name = Signal::new(String::new());
+#[component]
+fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+    let name = ctx.create_signal(String::new());
 
-    div()
+    div(ctx)
         .child(
-            h1().text("Hello ")
-                .dyn_child(cloned!((name) => move || {
-                    if *create_selector(cloned!((name) => move || !name.get().is_empty())).get() {
-                        span()
-                            .dyn_text(cloned!((name) => move || name.get().to_string()))
-                            .build()
+            h1(ctx)
+                .text("Hello ")
+                .dyn_child(move || {
+                    if *ctx.create_selector(move || !name.get().is_empty()).get() {
+                        span(ctx).dyn_text(move || name.get().to_string()).build()
                     } else {
-                        span().text("World").build()
+                        span(ctx).text("World").build()
                     }
-                }))
+                })
                 .text("!")
                 .build(),
         )
-        .child(input().bind_value(name).build())
+        .child(input(ctx).bind_value(&name).build())
         .build()
 }
 
@@ -28,5 +27,5 @@ fn main() {
     console_error_panic_hook::set_once();
     console_log::init_with_level(log::Level::Debug).unwrap();
 
-    sycamore::render(|| view! { App() });
+    sycamore::render(|ctx| view! {ctx, App() });
 }

--- a/examples/hello-builder/src/main.rs
+++ b/examples/hello-builder/src/main.rs
@@ -1,0 +1,32 @@
+use sycamore::builder::html::*;
+use sycamore::prelude::*;
+
+#[component(App<G>)]
+fn app() -> View<G> {
+    let name = Signal::new(String::new());
+
+    div()
+        .child(
+            h1().text("Hello ")
+                .dyn_child(cloned!((name) => move || {
+                    if *create_selector(cloned!((name) => move || !name.get().is_empty())).get() {
+                        span()
+                            .dyn_text(cloned!((name) => move || name.get().to_string()))
+                            .build()
+                    } else {
+                        span().text("World").build()
+                    }
+                }))
+                .text("!")
+                .build(),
+        )
+        .child(input().bind_value(name).build())
+        .build()
+}
+
+fn main() {
+    console_error_panic_hook::set_once();
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    sycamore::render(|| view! { App() });
+}

--- a/packages/sycamore-macro/src/view/parse.rs
+++ b/packages/sycamore-macro/src/view/parse.rs
@@ -115,7 +115,6 @@ impl Parse for ElementTag {
         } else {
             let tag = format!(
                 "{tag}-{extended}",
-                tag = tag,
                 extended = extended
                     .into_iter()
                     .map(|x| x.1.to_string())

--- a/packages/sycamore-macro/src/view/parse.rs
+++ b/packages/sycamore-macro/src/view/parse.rs
@@ -115,6 +115,7 @@ impl Parse for ElementTag {
         } else {
             let tag = format!(
                 "{tag}-{extended}",
+                tag = tag,
                 extended = extended
                     .into_iter()
                     .map(|x| x.1.to_string())


### PR DESCRIPTION
I have finally started work on the task of porting my code to sycamore 0.8, and thought I would give the builder api some love.

I have resurrected this example for selfish reasons as well (so that I have a template for writing up minimal reproduction cases, when I run into problems).

