### PR TITLE
Refactor sycamore-reactive crate to unify `Scope` and `BoundedScope`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Sycamore is a _reactive_ library for creating web apps in **Rust** and **WebAsse
 
 ```rust
 #[component]
-fn Hello<G: Html>(ctx: ScopeRef) -> View<G> {
+fn Hello<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         p { "Hello World!" }
     }

--- a/docs/next/advanced/contexts.md
+++ b/docs/next/advanced/contexts.md
@@ -54,7 +54,7 @@ To access the context, use the `use_context` method.
 
 ```rust
 #[component]
-fn ChildComponent<G: Html>(ctx: ScopeRef) -> View<G> {
+fn ChildComponent<G: Html>(ctx: Scope) -> View<G> {
     let dark_mode = ctx.use_context::<Signal<DarkMode>>();
     // ...
 }

--- a/docs/next/basics/components.md
+++ b/docs/next/basics/components.md
@@ -4,7 +4,7 @@ Any serious UI framework needs a way to compose and abstract UI elements. In Syc
 accomplished using components.
 
 Components in `sycamore` are simply functions slapped with the `#[component]` attribute that take a
-argument of type `ScopeRef` (a reactive scope). Component functions only run once (unlike React
+argument of type `Scope` (a reactive scope). Component functions only run once (unlike React
 where functional-components are called on every render). Think of it as a builder-pattern for
 constructing UI.
 
@@ -13,7 +13,7 @@ convention to name components using `PascalCase`.
 
 ```rust
 #[component]
-fn MyComponent<G: Html>(ctx: ScopeRef) -> View<G> {
+fn MyComponent<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         // ...
     }
@@ -74,7 +74,7 @@ struct MyProps<'a> {
 }
 
 #[component]
-fn MyComponent<'a, G: Html>(ctx: ScopeRef<'a>, props: MyProps<'a>) -> View<G> {
+fn MyComponent<'a, G: Html>(ctx: Scope<'a>, props: MyProps<'a>) -> View<G> {
     view! {
         div(class="my-component") {
             "Value: " (props.value.get())
@@ -91,7 +91,7 @@ view! {
 state.set(1); // automatically updates value in MyComponent
 ```
 
-Note how the `'a` lifetime is used to ensure that the data lives as long as the `ScopeRef`.
+Note how the `'a` lifetime is used to ensure that the data lives as long as the `Scope`.
 
 ## Lifecycle
 
@@ -108,7 +108,7 @@ can also be used to schedule a callback when the component is destroyed.
 
 ```rust
 #[component]
-fn MyComponent(ctx: ScopeRef) -> View<G> {
+fn MyComponent(ctx: Scope) -> View<G> {
     ctx.on_cleanup(|| {
         // Perform cleanup.
     });

--- a/docs/posts/new-reactive-primitives.md
+++ b/docs/posts/new-reactive-primitives.md
@@ -124,7 +124,7 @@ possibility on our roadmap:
 
 ```rust
 #[component]
-async fn AsyncFetch<G: Html>(ctx: ScopeRef) -> View<G> {
+async fn AsyncFetch<G: Html>(ctx: Scope) -> View<G> {
     let data = fetch_data().await;
     let derived = ctx.create_memo(|| data);
     //            ^^^ -> We can still access `ctx`, even after the `.await` suspension point.

--- a/examples/components/src/main.rs
+++ b/examples/components/src/main.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-fn MyComponent<'a, G: Html>(ctx: ScopeRef<'a>, props: &'a Signal<i32>) -> View<G> {
+fn MyComponent<'a, G: Html>(ctx: Scope<'a>, props: &'a Signal<i32>) -> View<G> {
     view! { ctx,
         div(class="my-component") {
             "My component"
@@ -14,7 +14,7 @@ fn MyComponent<'a, G: Html>(ctx: ScopeRef<'a>, props: &'a Signal<i32>) -> View<G
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let state = ctx.create_signal(0);
 
     let increment = |_| state.set(*state.get() + 1);

--- a/examples/context/src/main.rs
+++ b/examples/context/src/main.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-fn Counter<G: Html>(ctx: ScopeRef) -> View<G> {
+fn Counter<G: Html>(ctx: Scope) -> View<G> {
     let counter = ctx.use_context::<RcSignal<i32>>();
 
     view! { ctx,
@@ -12,7 +12,7 @@ fn Counter<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-pub fn Controls<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn Controls<G: Html>(ctx: Scope) -> View<G> {
     let state = ctx.use_context::<RcSignal<i32>>();
     let increment = move |_| state.set(*state.get() + 1);
     let decrement = move |_| state.set(*state.get() - 1);
@@ -26,7 +26,7 @@ pub fn Controls<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let counter = create_rc_signal(0i32);
     ctx.provide_context(counter);
 

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let state = ctx.create_signal(0i32);
     let increment = |_| state.set(*state.get() + 1);
     let decrement = |_| state.set(*state.get() - 1);

--- a/examples/hello-builder/src/main.rs
+++ b/examples/hello-builder/src/main.rs
@@ -7,7 +7,7 @@ use sycamore::builder::prelude::*;
 use sycamore::prelude::*;
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let name = ctx.create_signal(String::new());
     h(div)
         .c(h(h1)
@@ -15,7 +15,7 @@ fn App<G: Html>(ctx: ScopeRef) -> View<G> {
             .dyn_if(
                 || !name.get().is_empty(),
                 || h(span).dyn_t(|| name.get().to_string()),
-                || h(span).t("World").view(ctx),
+                || h(span).t("World"),
             )
             .t("!"))
         .c(h(input).bind_value(name))

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         p {
             "Hello World!"

--- a/examples/higher-order-components/src/main.rs
+++ b/examples/higher-order-components/src/main.rs
@@ -3,15 +3,15 @@
 use sycamore::prelude::*;
 
 #[component]
-fn MyComponent<G: Html>(ctx: ScopeRef, props: i32) -> View<G> {
+fn MyComponent<G: Html>(ctx: Scope, props: i32) -> View<G> {
     view! { ctx,
         (props)
     }
 }
 
 fn higher_order_component<G: Html>(
-    Comp: &dyn Fn(ScopeRef, i32) -> View<G>,
-) -> impl Fn(ScopeRef, ()) -> View<G> + '_ {
+    Comp: &dyn Fn(Scope, i32) -> View<G>,
+) -> impl Fn(Scope, ()) -> View<G> + '_ {
     move |ctx, _| {
         view! { ctx,
             div {

--- a/examples/http-request/src/main.rs
+++ b/examples/http-request/src/main.rs
@@ -20,7 +20,7 @@ async fn fetch_visits(id: &str) -> Result<Visits, reqwasm::Error> {
 }
 
 #[component]
-async fn VisitsCount<G: Html>(ctx: ScopeRef<'_>) -> View<G> {
+async fn VisitsCount<G: Html>(ctx: Scope<'_>) -> View<G> {
     let id = "sycamore-visits-counter";
     let visits = fetch_visits(id).await.unwrap_or_default();
 
@@ -37,7 +37,7 @@ async fn VisitsCount<G: Html>(ctx: ScopeRef<'_>) -> View<G> {
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         div {
             p { "Page Visit Counter" }

--- a/examples/hydrate/src/main.rs
+++ b/examples/hydrate/src/main.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-fn Counter<G: Html>(ctx: ScopeRef) -> View<G> {
+fn Counter<G: Html>(ctx: Scope) -> View<G> {
     let state = ctx.create_signal(0i32);
     let increment = |_| state.set(*state.get() + 1);
     let decrement = |_| state.set(*state.get() - 1);
@@ -17,7 +17,7 @@ fn Counter<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-fn Hello<G: Html>(ctx: ScopeRef) -> View<G> {
+fn Hello<G: Html>(ctx: Scope) -> View<G> {
     let name = ctx.create_signal(String::new());
 
     view! { ctx,
@@ -39,7 +39,7 @@ fn Hello<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         p { "Hydration" }
         br

--- a/examples/iteration/src/main.rs
+++ b/examples/iteration/src/main.rs
@@ -7,7 +7,7 @@ struct Cat {
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let items = ctx.create_signal(vec![
         Cat {
             id: "J---aiyznGQ",

--- a/examples/js-framework-benchmark/src/main.rs
+++ b/examples/js-framework-benchmark/src/main.rs
@@ -49,7 +49,7 @@ struct ButtonProps<'a> {
 }
 
 #[component]
-fn Button<'a, G: Html>(ctx: ScopeRef<'a>, props: ButtonProps<'a>) -> View<G> {
+fn Button<'a, G: Html>(ctx: Scope<'a>, props: ButtonProps<'a>) -> View<G> {
     let ButtonProps { id, text, callback } = props;
 
     view! { ctx,
@@ -99,7 +99,7 @@ fn build_data(count: usize) -> Vec<RowData> {
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let data = ctx.create_signal(Vec::<RowData>::new());
     let selected = ctx.create_signal(None::<usize>);
 

--- a/examples/motion/src/main.rs
+++ b/examples/motion/src/main.rs
@@ -5,7 +5,7 @@ use sycamore::motion::ScopeMotionExt;
 use sycamore::prelude::*;
 
 #[component]
-fn CreateRAF<G: Html>(ctx: ScopeRef) -> View<G> {
+fn CreateRAF<G: Html>(ctx: Scope) -> View<G> {
     let state = ctx.create_signal(0i32);
     let (_running, start, stop) = ctx.create_raf(|| {
         state.set(*state.get() + 1);
@@ -20,7 +20,7 @@ fn CreateRAF<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-fn Tweened<G: Html>(ctx: ScopeRef) -> View<G> {
+fn Tweened<G: Html>(ctx: Scope) -> View<G> {
     let progress =
         ctx.create_tweened_signal([0.0f32, 1.0], Duration::from_millis(250), easing::quad_out);
 

--- a/examples/ssr/src/main.rs
+++ b/examples/ssr/src/main.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let name = ctx.create_signal(String::new());
 
     let handle_change = move |_| unreachable!();

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -3,7 +3,7 @@ use sycamore::futures::ScopeSpawnLocal;
 use sycamore::prelude::*;
 
 #[component]
-fn TimerCounter<G: Html>(ctx: ScopeRef) -> View<G> {
+fn TimerCounter<G: Html>(ctx: Scope) -> View<G> {
     let state = ctx.create_signal(0);
 
     ctx.spawn_local(async move {

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -135,7 +135,7 @@ fn main() {
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     // Initialize application state
     let local_storage = web_sys::window()
         .unwrap()
@@ -180,7 +180,7 @@ fn App<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-pub fn Copyright<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn Copyright<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         footer(class="info") {
             p { "Double click to edit a todo" }
@@ -197,7 +197,7 @@ pub fn Copyright<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-pub fn Header<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn Header<G: Html>(ctx: Scope) -> View<G> {
     let app_state = ctx.use_context::<AppState>();
     let value = ctx.create_signal(String::new());
     let input_ref = ctx.create_node_ref();
@@ -234,7 +234,7 @@ pub fn Header<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-pub fn Item<G: Html>(ctx: ScopeRef, todo: RcSignal<Todo>) -> View<G> {
+pub fn Item<G: Html>(ctx: Scope, todo: RcSignal<Todo>) -> View<G> {
     let app_state = ctx.use_context::<AppState>();
     // Make `todo` live as long as the scope.
     let todo = ctx.create_ref(todo);
@@ -353,7 +353,7 @@ pub fn Item<G: Html>(ctx: ScopeRef, todo: RcSignal<Todo>) -> View<G> {
 }
 
 #[component]
-pub fn List<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn List<G: Html>(ctx: Scope) -> View<G> {
     let app_state = ctx.use_context::<AppState>();
     let todos_left = ctx.create_selector(|| app_state.todos_left());
 
@@ -405,7 +405,7 @@ pub fn List<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-pub fn TodoFilter<G: Html>(ctx: ScopeRef, filter: Filter) -> View<G> {
+pub fn TodoFilter<G: Html>(ctx: Scope, filter: Filter) -> View<G> {
     let app_state = ctx.use_context::<AppState>();
     let selected = move || filter == *app_state.filter.get();
     let set_filter = |filter| app_state.filter.set(filter);
@@ -424,7 +424,7 @@ pub fn TodoFilter<G: Html>(ctx: ScopeRef, filter: Filter) -> View<G> {
 }
 
 #[component]
-pub fn Footer<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn Footer<G: Html>(ctx: Scope) -> View<G> {
     let app_state = ctx.use_context::<AppState>();
 
     let items_text = || match app_state.todos_left() {

--- a/examples/transitions/src/main.rs
+++ b/examples/transitions/src/main.rs
@@ -21,7 +21,7 @@ impl Tab {
 }
 
 #[component]
-async fn Child<G: Html>(ctx: ScopeRef<'_>, tab: Tab) -> View<G> {
+async fn Child<G: Html>(ctx: Scope<'_>, tab: Tab) -> View<G> {
     let delay_ms = rand::thread_rng().gen_range(200..500);
     TimeoutFuture::new(delay_ms).await;
 
@@ -34,7 +34,7 @@ async fn Child<G: Html>(ctx: ScopeRef<'_>, tab: Tab) -> View<G> {
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let tab = ctx.create_signal(Tab::One);
     let transition = ctx.use_transition();
     let update = move |x| transition.start(move || tab.set(x));

--- a/packages/sycamore-futures/src/lib.rs
+++ b/packages/sycamore-futures/src/lib.rs
@@ -29,11 +29,11 @@ pub trait ScopeSpawnLocal<'a> {
     /// Spawns a `!Send` future on the current scope. If the scope is destroyed before the future is
     /// completed, it is aborted immediately. This ensures that it is impossible to access any
     /// values referencing the scope after they are destroyed.
-    fn spawn_local(&'a self, f: impl Future<Output = ()> + 'a);
+    fn spawn_local(self, f: impl Future<Output = ()> + 'a);
 }
 
 impl<'a> ScopeSpawnLocal<'a> for Scope<'a> {
-    fn spawn_local(&'a self, f: impl Future<Output = ()> + 'a) {
+    fn spawn_local(self, f: impl Future<Output = ()> + 'a) {
         let boxed: Pin<Box<dyn Future<Output = ()> + 'a>> = Box::pin(f);
         // SAFETY: We are just transmuting the lifetime here so that we can spawn the future.
         // This is safe because we wrap the future in an `Abortable` future which will be

--- a/packages/sycamore-macro/src/component/mod.rs
+++ b/packages/sycamore-macro/src/component/mod.rs
@@ -46,7 +46,7 @@ impl Parse for ComponentFunction {
                 if inputs.is_empty() {
                     return Err(syn::Error::new(
                         sig.inputs.span(),
-                        "component must take at least one argument of type `sycamore::reactive::ScopeRef`",
+                        "component must take at least one argument of type `sycamore::reactive::Scope`",
                     ));
                 }
 

--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -23,7 +23,7 @@ pub fn view(view: TokenStream) -> TokenStream {
 /// use sycamore::prelude::*;
 ///
 /// #[component]
-/// pub fn MyComponent<G: Html>(ctx: ScopeRef) -> View<G> {
+/// pub fn MyComponent<G: Html>(ctx: Scope) -> View<G> {
 ///     let cool_button: G = node! { ctx, button { "The coolest 😎" } };
 ///
 ///     cool_button.set_property("myProperty", &"Epic!".into());

--- a/packages/sycamore-macro/src/view/codegen.rs
+++ b/packages/sycamore-macro/src/view/codegen.rs
@@ -482,7 +482,7 @@ impl Codegen {
                         props_quoted.extend(quote! {
                             .children(
                                 ::sycamore::component::Children::new(#ctx, move |__ctx| {
-                                    let __ctx: &ScopeRef = &__ctx;
+                                    let __ctx: &Scope = &__ctx;
                                     #view_root
                                 })
                             )

--- a/packages/sycamore-macro/src/view/mod.rs
+++ b/packages/sycamore-macro/src/view/mod.rs
@@ -36,7 +36,7 @@ pub fn view_impl(view_root: WithCtxArg<ViewRoot>) -> TokenStream {
     let quoted = codegen_state.view_root(&view_root.rest);
     quote! {{
         #[allow(unused_variables)]
-        let #ctx: ::sycamore::reactive::ScopeRef = &#ctx; // Make sure that ctx is used.
+        let #ctx: ::sycamore::reactive::BoundedScope = #ctx; // Make sure that ctx is used.
         #quoted
     }}
 }
@@ -49,7 +49,7 @@ pub fn node_impl(elem: WithCtxArg<Element>) -> TokenStream {
     let quoted = codegen_state.element(&elem.rest);
     quote! {{
         #[allow(unused_variables)]
-        let #ctx: ::sycamore::reactive::ScopeRef = &#ctx; // Make sure that ctx is used.
+        let #ctx: ::sycamore::reactive::BoundedScope = #ctx; // Make sure that ctx is used.
         #quoted
     }}
 }

--- a/packages/sycamore-macro/tests/component/component-fail.stderr
+++ b/packages/sycamore-macro/tests/component/component-fail.stderr
@@ -4,7 +4,7 @@ error: function must return `sycamore::view::View`
 5 | fn comp1<G: Html>() {
   | ^^
 
-error: component must take at least one argument of type `sycamore::reactive::ScopeRef`
+error: component must take at least one argument of type `sycamore::reactive::Scope`
  --> tests/component/component-fail.rs:9:1
   |
 9 | #[component]

--- a/packages/sycamore-macro/tests/component/component-pass.rs
+++ b/packages/sycamore-macro/tests/component/component-pass.rs
@@ -1,12 +1,12 @@
 use sycamore::prelude::*;
 
 #[component]
-fn comp1<G: Html>(_ctx: ScopeRef) -> View<G> {
+fn comp1<G: Html>(_ctx: Scope) -> View<G> {
     todo!();
 }
 
 #[component]
-fn comp2<G: Html>(_ctx: ScopeRef) -> View<G> {
+fn comp2<G: Html>(_ctx: Scope) -> View<G> {
     todo!();
 }
 

--- a/packages/sycamore-macro/tests/view/component-fail.rs
+++ b/packages/sycamore-macro/tests/view/component-fail.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-fn c(ctx: ScopeRef) -> View<G> {
+fn c(ctx: Scope) -> View<G> {
     view! {
         div
     }

--- a/packages/sycamore-macro/tests/view/component-fail.stderr
+++ b/packages/sycamore-macro/tests/view/component-fail.stderr
@@ -19,7 +19,7 @@ error: unexpected end of input, expected either `(` or `{`
 error[E0412]: cannot find type `G` in this scope
  --> tests/view/component-fail.rs:4:29
   |
-4 | fn c(ctx: ScopeRef) -> View<G> {
+4 | fn c(ctx: Scope) -> View<G> {
   |     -                       ^ not found in this scope
   |     |
   |     help: you might be missing a type parameter: `<G>`
@@ -33,7 +33,7 @@ error[E0425]: cannot find function, tuple struct or tuple variant `UnknownCompon
 error[E0425]: cannot find function, tuple struct or tuple variant `C` in this scope
   --> tests/view/component-fail.rs:15:39
    |
-4  | fn c(ctx: ScopeRef) -> View<G> {
+4  | fn c(ctx: Scope) -> View<G> {
    | ------------------------------ similarly named function `c` defined here
 ...
 15 |         let _: View<G> = view! { ctx, C(1) };

--- a/packages/sycamore-macro/tests/view/component-fail.stderr
+++ b/packages/sycamore-macro/tests/view/component-fail.stderr
@@ -17,10 +17,10 @@ error: unexpected end of input, expected either `(` or `{`
    = note: this error originates in the macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0412]: cannot find type `G` in this scope
- --> tests/view/component-fail.rs:4:29
+ --> tests/view/component-fail.rs:4:26
   |
 4 | fn c(ctx: Scope) -> View<G> {
-  |     -                       ^ not found in this scope
+  |     -                    ^ not found in this scope
   |     |
   |     help: you might be missing a type parameter: `<G>`
 
@@ -34,7 +34,7 @@ error[E0425]: cannot find function, tuple struct or tuple variant `C` in this sc
   --> tests/view/component-fail.rs:15:39
    |
 4  | fn c(ctx: Scope) -> View<G> {
-   | ------------------------------ similarly named function `c` defined here
+   | --------------------------- similarly named function `c` defined here
 ...
 15 |         let _: View<G> = view! { ctx, C(1) };
    |                                       ^

--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-pub fn Component<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn Component<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         div
     }

--- a/packages/sycamore-reactive/src/arena.rs
+++ b/packages/sycamore-reactive/src/arena.rs
@@ -33,7 +33,7 @@ impl<'a> ScopeArena<'a> {
         // - It is allocated on the heap and therefore has a stable address.
         // - self.inner is append only. That means that the Box<_> will not be dropped until Self is
         //   dropped.
-        // - The drop code for ScopeRef never reads the allocated value and therefore does not
+        // - The drop code for Scope never reads the allocated value and therefore does not
         //   create a stacked-borrows violation.
         unsafe { &*ptr }
     }

--- a/packages/sycamore-reactive/src/iter.rs
+++ b/packages/sycamore-reactive/src/iter.rs
@@ -23,9 +23,9 @@ impl<'a> Scope<'a> {
     ///
     ///  _Credits: Based on TypeScript implementation in <https://github.com/solidjs/solid>_
     pub fn map_keyed<T, K, U>(
-        &'a self,
+        self,
         list: &'a ReadSignal<Vec<T>>,
-        map_fn: impl for<'child_lifetime> Fn(BoundedScopeRef<'child_lifetime, 'a>, T) -> U + 'a,
+        map_fn: impl for<'child_lifetime> Fn(BoundedScope<'child_lifetime, 'a>, T) -> U + 'a,
         key_fn: impl Fn(&T) -> K + 'a,
     ) -> &'a ReadSignal<Vec<U>>
     where
@@ -216,9 +216,9 @@ impl<'a> Scope<'a> {
     ///   [`Signal`]) and therefore reactive.
     /// * `map_fn` - A closure that maps from the input type to the output type.
     pub fn map_indexed<T, U>(
-        &'a self,
+        self,
         list: &'a ReadSignal<Vec<T>>,
-        map_fn: impl for<'child_lifetime> Fn(BoundedScopeRef<'child_lifetime, 'a>, T) -> U + 'a,
+        map_fn: impl for<'child_lifetime> Fn(BoundedScope<'child_lifetime, 'a>, T) -> U + 'a,
     ) -> &'a ReadSignal<Vec<U>>
     where
         T: PartialEq + Clone,

--- a/packages/sycamore-reactive/src/memo.rs
+++ b/packages/sycamore-reactive/src/memo.rs
@@ -46,7 +46,7 @@ impl<'a> Scope<'a> {
     /// assert_eq!(*double.get(), 2);
     /// # });
     /// ```
-    pub fn create_memo<U: 'a>(&'a self, f: impl FnMut() -> U + 'a) -> &'a ReadSignal<U> {
+    pub fn create_memo<U: 'a>(self, f: impl FnMut() -> U + 'a) -> &'a ReadSignal<U> {
         self.create_selector_with(f, |_, _| false)
     }
 
@@ -71,7 +71,7 @@ impl<'a> Scope<'a> {
     /// # });
     /// ```
     pub fn create_selector<U: PartialEq + 'a>(
-        &'a self,
+        self,
         f: impl FnMut() -> U + 'a,
     ) -> &'a ReadSignal<U> {
         self.create_selector_with(f, PartialEq::eq)
@@ -87,7 +87,7 @@ impl<'a> Scope<'a> {
     /// To use the type's [`PartialEq`] implementation instead of a custom function, use
     /// [`create_selector`](Self::create_selector).
     pub fn create_selector_with<U: 'a>(
-        &'a self,
+        self,
         mut f: impl FnMut() -> U + 'a,
         eq_f: impl Fn(&U, &U) -> bool + 'a,
     ) -> &'a ReadSignal<U> {
@@ -146,7 +146,7 @@ impl<'a> Scope<'a> {
     /// # });
     /// ```
     pub fn create_reducer<U, Msg>(
-        &'a self,
+        self,
         initial: U,
         reduce: impl Fn(&U, Msg) -> U + 'a,
     ) -> (&'a ReadSignal<U>, impl Fn(Msg) + 'a) {

--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -130,7 +130,7 @@ impl<T> ReadSignal<T> {
     /// # use sycamore_reactive::*;
     /// # create_scope_immediate(|ctx| {
     /// let state = ctx.create_signal(1);
-    /// let double = state.map(&ctx, |&x| x * 2);
+    /// let double = state.map(ctx, |&x| x * 2);
     /// assert_eq!(*double.get(), 2);
     ///
     /// state.set(2);
@@ -140,7 +140,7 @@ impl<T> ReadSignal<T> {
     #[must_use]
     pub fn map<'a, U>(
         &'a self,
-        ctx: ScopeRef<'a>,
+        ctx: Scope<'a>,
         mut f: impl FnMut(&T) -> U + 'a,
     ) -> &'a ReadSignal<U> {
         ctx.create_memo(move || f(&self.get()))

--- a/packages/sycamore-router/Cargo.toml
+++ b/packages/sycamore-router/Cargo.toml
@@ -32,3 +32,6 @@ features = [
   "Window",
 ]
 version = "0.3.56"
+
+[dev-dependencies]
+sycamore = { path = "../sycamore", features = ["ssr"] }

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -145,7 +145,7 @@ fn base_pathname() -> String {
 pub struct RouterProps<'a, R, F, I, G>
 where
     R: Route + 'a,
-    F: FnOnce(ScopeRef<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
+    F: FnOnce(Scope<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
     I: Integration,
     G: GenericNode,
 {
@@ -158,7 +158,7 @@ where
 impl<'a, R, F, I, G> RouterProps<'a, R, F, I, G>
 where
     R: Route + 'a,
-    F: FnOnce(ScopeRef<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
+    F: FnOnce(Scope<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
     I: Integration,
     G: GenericNode,
 {
@@ -176,12 +176,12 @@ where
 /// For server environments, see [`StaticRouter`].
 #[component]
 pub fn Router<'a, G: Html, R, F, I>(
-    ctx: ScopeRef<'a>,
+    ctx: Scope<'a>,
     props: RouterProps<'a, R, F, I, G>,
 ) -> View<G>
 where
     R: Route + 'a,
-    F: FnOnce(ScopeRef<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
+    F: FnOnce(Scope<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
     I: Integration + 'static,
 {
     let RouterProps {
@@ -253,7 +253,7 @@ where
 pub struct StaticRouterProps<'a, R, F, G>
 where
     R: Route + 'a,
-    F: Fn(ScopeRef<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
+    F: Fn(Scope<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
     G: GenericNode,
 {
     view: F,
@@ -265,7 +265,7 @@ where
 impl<'a, R, F, G> StaticRouterProps<'a, R, F, G>
 where
     R: Route,
-    F: Fn(ScopeRef<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
+    F: Fn(Scope<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
     G: GenericNode,
 {
     /// Create a new [`StaticRouterProps`].
@@ -284,12 +284,12 @@ where
 /// the route preload to finish loading.
 #[component]
 pub fn StaticRouter<'a, G: Html, R, F>(
-    ctx: ScopeRef<'a>,
+    ctx: Scope<'a>,
     props: StaticRouterProps<'a, R, F, G>,
 ) -> View<G>
 where
     R: Route + 'static,
-    F: Fn(ScopeRef<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
+    F: Fn(Scope<'a>, &'a ReadSignal<R>) -> View<G> + 'a,
 {
     let StaticRouterProps {
         view,
@@ -380,7 +380,7 @@ mod tests {
         }
 
         #[component]
-        fn Comp<G: Html>(ctx: ScopeRef, path: String) -> View<G> {
+        fn Comp<G: Html>(ctx: Scope, path: String) -> View<G> {
             let route = Routes::match_route(
                 &path
                     .split('/')

--- a/packages/sycamore/benches/ssr.rs
+++ b/packages/sycamore/benches/ssr.rs
@@ -5,7 +5,7 @@ pub fn bench(c: &mut Criterion) {
     c.bench_function("ssr_small", |b| {
         b.iter(|| {
             #[component]
-            fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+            fn App<G: Html>(ctx: Scope) -> View<G> {
                 view! { ctx,
                     div(class="my-container") {
                         p { "Hello World!" }
@@ -20,7 +20,7 @@ pub fn bench(c: &mut Criterion) {
     c.bench_function("ssr_medium", |b| {
         b.iter(|| {
             #[component]
-            fn ListItem<G: Html>(ctx: ScopeRef, value: i32) -> View<G> {
+            fn ListItem<G: Html>(ctx: Scope, value: i32) -> View<G> {
                 view! { ctx,
                     p {
                         span(class="placeholder")
@@ -33,7 +33,7 @@ pub fn bench(c: &mut Criterion) {
             }
 
             #[component]
-            fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+            fn App<G: Html>(ctx: Scope) -> View<G> {
                 let values = ctx.create_signal((0i32..=10).collect::<Vec<_>>());
 
                 view! { ctx,

--- a/packages/sycamore/src/component.rs
+++ b/packages/sycamore/src/component.rs
@@ -48,19 +48,19 @@ impl Prop for () {
 /// Get the builder for the component function.
 #[doc(hidden)]
 pub fn element_like_component_builder<'a, T: Prop + 'a, G: GenericNode>(
-    _f: &impl FnOnce(ScopeRef<'a>, T) -> View<G>,
+    _f: &impl FnOnce(Scope<'a>, T) -> View<G>,
 ) -> T::Builder {
     T::builder()
 }
 
 /// Component children.
 pub struct Children<'a, G: GenericNode> {
-    f: Box<dyn FnOnce(BoundedScopeRef<'_, 'a>) -> View<G> + 'a>,
+    f: Box<dyn FnOnce(BoundedScope<'_, 'a>) -> View<G> + 'a>,
 }
 
 impl<'a, F, G: GenericNode> From<F> for Children<'a, G>
 where
-    F: FnOnce(BoundedScopeRef<'_, 'a>) -> View<G> + 'a,
+    F: FnOnce(BoundedScope<'_, 'a>) -> View<G> + 'a,
 {
     fn from(f: F) -> Self {
         Self { f: Box::new(f) }
@@ -68,25 +68,18 @@ where
 }
 
 impl<'a, G: GenericNode> Children<'a, G> {
-    /// Instantiate the child [`View`] with the passed [`ScopeRef`].
-    pub fn call<'b>(self, ctx: ScopeRef<'b>) -> View<G>
-    where
-        'a: 'b,
-    {
-        let bounded = BoundedScopeRef::<'b, 'a>::new(ctx);
-        (self.f)(bounded)
+    /// Instantiate the child [`View`] with the passed [`Scope`].
+    pub fn call(self, ctx: BoundedScope<'_, 'a>) -> View<G> {
+        (self.f)(ctx)
     }
 
-    /// Instantiate the child [`View`] with the passed [`BoundedScopeRef`].
-    pub fn call_with_bounded_scope(self, ctx: BoundedScopeRef<'_, 'a>) -> View<G> {
+    /// Instantiate the child [`View`] with the passed [`BoundedScope`].
+    pub fn call_with_bounded_scope(self, ctx: BoundedScope<'_, 'a>) -> View<G> {
         (self.f)(ctx)
     }
 
     /// Create a new [`Children`] from a closure.
-    pub fn new(
-        _ctx: ScopeRef<'a>,
-        f: impl FnOnce(BoundedScopeRef<'_, 'a>) -> View<G> + 'a,
-    ) -> Self {
+    pub fn new(_ctx: Scope<'a>, f: impl FnOnce(BoundedScope<'_, 'a>) -> View<G> + 'a) -> Self {
         Self { f: Box::new(f) }
     }
 }

--- a/packages/sycamore/src/flow.rs
+++ b/packages/sycamore/src/flow.rs
@@ -11,7 +11,7 @@ use crate::prelude::*;
 #[derive(Prop)]
 pub struct KeyedProps<'a, T, F, G: GenericNode, K, Key>
 where
-    F: Fn(BoundedScopeRef<'_, 'a>, T) -> View<G> + 'a,
+    F: Fn(BoundedScope<'_, 'a>, T) -> View<G> + 'a,
     K: Fn(&T) -> Key + 'a,
     Key: Clone + Hash + Eq,
     T: Clone + PartialEq,
@@ -30,11 +30,11 @@ where
 /// For non keyed iteration, see [`Indexed`].
 #[component]
 pub fn Keyed<'a, G: GenericNode, T, F, K, Key>(
-    ctx: ScopeRef<'a>,
+    ctx: Scope<'a>,
     props: KeyedProps<'a, T, F, G, K, Key>,
 ) -> View<G>
 where
-    F: Fn(BoundedScopeRef<'_, 'a>, T) -> View<G> + 'a,
+    F: Fn(BoundedScope<'_, 'a>, T) -> View<G> + 'a,
     K: Fn(&T) -> Key + 'a,
     Key: Clone + Hash + Eq,
     T: Clone + Eq,
@@ -53,7 +53,7 @@ where
 #[derive(Prop)]
 pub struct IndexedProps<'a, G: GenericNode, T, F>
 where
-    F: Fn(BoundedScopeRef<'_, 'a>, T) -> View<G> + 'a,
+    F: Fn(BoundedScope<'_, 'a>, T) -> View<G> + 'a,
 {
     iterable: &'a ReadSignal<Vec<T>>,
     /// The map function that renders a [`View`] for each element in `iterable`.
@@ -67,12 +67,12 @@ where
 /// For keyed iteration, see [`Keyed`].
 #[component]
 pub fn Indexed<'a, G: GenericNode, T, F>(
-    ctx: ScopeRef<'a>,
+    ctx: Scope<'a>,
     props: IndexedProps<'a, G, T, F>,
 ) -> View<G>
 where
     T: Clone + PartialEq,
-    F: Fn(BoundedScopeRef<'_, 'a>, T) -> View<G> + 'a,
+    F: Fn(BoundedScope<'_, 'a>, T) -> View<G> + 'a,
 {
     let IndexedProps { iterable, view } = props;
 

--- a/packages/sycamore/src/futures.rs
+++ b/packages/sycamore/src/futures.rs
@@ -28,14 +28,14 @@ pub trait ScopeFuturesExt<'a> {
     ///
     /// TODO: docs + example
     #[deprecated = "use Scope::spawn_local instead"]
-    fn create_resource<U, F>(&'a self, f: F) -> RcSignal<Option<U>>
+    fn create_resource<U, F>(self, f: F) -> RcSignal<Option<U>>
     where
         U: 'static,
         F: Future<Output = U> + 'static;
 }
 
 impl<'a> ScopeFuturesExt<'a> for Scope<'a> {
-    fn create_resource<U, F>(&'a self, f: F) -> RcSignal<Option<U>>
+    fn create_resource<U, F>(self, f: F) -> RcSignal<Option<U>>
     where
         U: 'static,
         F: Future<Output = U> + 'static,

--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -280,7 +280,7 @@ impl GenericNode for DomNode {
         self.node.unchecked_ref::<Element>().remove();
     }
 
-    fn event<'a>(&self, ctx: ScopeRef<'a>, name: &str, handler: Box<dyn Fn(Self::EventType) + 'a>) {
+    fn event<'a>(&self, ctx: Scope<'a>, name: &str, handler: Box<dyn Fn(Self::EventType) + 'a>) {
         // SAFETY: extend lifetime because the closure is dropped when the ctx is disposed,
         // preventing the handler from ever being accessed after its lifetime.
         let handler: Box<dyn Fn(Self::EventType) + 'static> =
@@ -319,7 +319,7 @@ impl Html for DomNode {
 /// Alias for [`render_to`] with `parent` being the `<body>` tag.
 ///
 /// _This API requires the following crate features to be activated: `dom`_
-pub fn render(view: impl FnOnce(ScopeRef<'_>) -> View<DomNode>) {
+pub fn render(view: impl FnOnce(Scope<'_>) -> View<DomNode>) {
     let window = web_sys::window().unwrap_throw();
     let document = window.document().unwrap_throw();
 
@@ -330,7 +330,7 @@ pub fn render(view: impl FnOnce(ScopeRef<'_>) -> View<DomNode>) {
 /// For rendering under the `<body>` tag, use [`render`] instead.
 ///
 /// _This API requires the following crate features to be activated: `dom`_
-pub fn render_to(view: impl FnOnce(ScopeRef<'_>) -> View<DomNode>, parent: &Node) {
+pub fn render_to(view: impl FnOnce(Scope<'_>) -> View<DomNode>, parent: &Node) {
     // Do not call the destructor function, effectively leaking the scope.
     let _ = render_get_scope(view, parent);
 }
@@ -347,7 +347,7 @@ pub fn render_to(view: impl FnOnce(ScopeRef<'_>) -> View<DomNode>, parent: &Node
 /// _This API requires the following crate features to be activated: `dom`_
 #[must_use = "please hold onto the ScopeDisposer until you want to clean things up, or use render_to() instead"]
 pub fn render_get_scope<'a>(
-    view: impl FnOnce(ScopeRef<'_>) -> View<DomNode> + 'a,
+    view: impl FnOnce(Scope<'_>) -> View<DomNode> + 'a,
     parent: &'a Node,
 ) -> ScopeDisposer<'a> {
     create_scope(|ctx| {

--- a/packages/sycamore/src/generic_node/hydrate_dom.rs
+++ b/packages/sycamore/src/generic_node/hydrate_dom.rs
@@ -209,7 +209,7 @@ impl GenericNode for HydrateNode {
     }
 
     #[inline]
-    fn event<'a>(&self, ctx: ScopeRef<'a>, name: &str, handler: Box<dyn Fn(Self::EventType) + 'a>) {
+    fn event<'a>(&self, ctx: Scope<'a>, name: &str, handler: Box<dyn Fn(Self::EventType) + 'a>) {
         self.node.event(ctx, name, handler);
     }
 
@@ -241,7 +241,7 @@ impl Html for HydrateNode {
 /// For rendering without hydration, use [`render`](super::render) instead.
 ///
 /// _This API requires the following crate features to be activated: `experimental-hydrate`, `dom`_
-pub fn hydrate(template: impl FnOnce(ScopeRef<'_>) -> View<HydrateNode>) {
+pub fn hydrate(template: impl FnOnce(Scope<'_>) -> View<HydrateNode>) {
     let window = web_sys::window().unwrap_throw();
     let document = window.document().unwrap_throw();
 
@@ -254,7 +254,7 @@ pub fn hydrate(template: impl FnOnce(ScopeRef<'_>) -> View<HydrateNode>) {
 /// For rendering without hydration, use [`render`](super::render) instead.
 ///
 /// _This API requires the following crate features to be activated: `experimental-hydrate`, `dom`_
-pub fn hydrate_to(view: impl FnOnce(ScopeRef<'_>) -> View<HydrateNode>, parent: &Node) {
+pub fn hydrate_to(view: impl FnOnce(Scope<'_>) -> View<HydrateNode>, parent: &Node) {
     // Do not call the destructor function, effectively leaking the scope.
     let _ = hydrate_get_scope(view, parent);
 }
@@ -267,7 +267,7 @@ pub fn hydrate_to(view: impl FnOnce(ScopeRef<'_>) -> View<HydrateNode>, parent: 
 /// _This API requires the following crate features to be activated: `experimental-hydrate`, `dom`_
 #[must_use = "please hold onto the ReactiveScope until you want to clean things up, or use render_to() instead"]
 pub fn hydrate_get_scope<'a>(
-    view: impl FnOnce(ScopeRef<'_>) -> View<HydrateNode> + 'a,
+    view: impl FnOnce(Scope<'_>) -> View<HydrateNode> + 'a,
     parent: &'a Node,
 ) -> ScopeDisposer<'a> {
     // Get children from parent into a View to set as the initial node value.

--- a/packages/sycamore/src/generic_node/mod.rs
+++ b/packages/sycamore/src/generic_node/mod.rs
@@ -13,7 +13,7 @@ use std::hash::Hash;
 use wasm_bindgen::prelude::*;
 use web_sys::Event;
 
-use crate::reactive::ScopeRef;
+use crate::reactive::Scope;
 
 #[cfg(feature = "dom")]
 pub use dom_node::*;
@@ -140,7 +140,7 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
     fn remove_self(&self);
 
     /// Add a event handler to the event `name`.
-    fn event<'a>(&self, ctx: ScopeRef<'a>, name: &str, handler: Box<dyn Fn(Self::EventType) + 'a>);
+    fn event<'a>(&self, ctx: Scope<'a>, name: &str, handler: Box<dyn Fn(Self::EventType) + 'a>);
 
     /// Update inner text of the node. If the node has elements, all the elements are replaced with
     /// a new text node.

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -312,7 +312,7 @@ impl GenericNode for SsrNode {
 
     fn event<'a>(
         &self,
-        _ctx: ScopeRef<'a>,
+        _ctx: Scope<'a>,
         _name: &str,
         _handler: Box<dyn Fn(Self::EventType) + 'a>,
     ) {
@@ -445,7 +445,7 @@ impl WriteToString for RawText {
 ///
 /// _This API requires the following crate features to be activated: `ssr`_
 #[must_use]
-pub fn render_to_string(view: impl FnOnce(ScopeRef<'_>) -> View<SsrNode>) -> String {
+pub fn render_to_string(view: impl FnOnce(Scope<'_>) -> View<SsrNode>) -> String {
     let mut ret = String::new();
     create_scope_immediate(|ctx| {
         let v = with_hydration_context(|| view(ctx));
@@ -466,7 +466,7 @@ pub fn render_to_string(view: impl FnOnce(ScopeRef<'_>) -> View<SsrNode>) -> Str
 /// _This API requires the following crate features to be activated: `suspense`, `ssr`_
 #[cfg(feature = "suspense")]
 pub async fn render_to_string_await_suspense(
-    view: impl FnOnce(ScopeRef<'_>) -> View<SsrNode> + 'static,
+    view: impl FnOnce(Scope<'_>) -> View<SsrNode> + 'static,
 ) -> String {
     use futures::channel::oneshot;
     use sycamore_futures::ScopeSpawnLocal;

--- a/packages/sycamore/src/noderef.rs
+++ b/packages/sycamore/src/noderef.rs
@@ -85,11 +85,11 @@ impl<G: GenericNode> fmt::Debug for NodeRef<G> {
 /// Extension trait for [`Scope`] adding the `create_node_ref` method.
 pub trait ScopeCreateNodeRef<'a> {
     /// Create a new [`NodeRef`] on the current [`Scope`].
-    fn create_node_ref<G: GenericNode>(&'a self) -> &'a NodeRef<G>;
+    fn create_node_ref<G: GenericNode>(self) -> &'a NodeRef<G>;
 }
 
 impl<'a> ScopeCreateNodeRef<'a> for Scope<'a> {
-    fn create_node_ref<G: GenericNode>(&'a self) -> &'a NodeRef<G> {
+    fn create_node_ref<G: GenericNode>(self) -> &'a NodeRef<G> {
         self.create_ref(NodeRef::new())
     }
 }

--- a/packages/sycamore/src/portal.rs
+++ b/packages/sycamore/src/portal.rs
@@ -19,7 +19,7 @@ where
 
 /// A portal into another part of the DOM.
 #[component]
-pub fn Portal<'a, G: Html>(ctx: ScopeRef<'a>, props: PortalProps<'a, G>) -> View<G> {
+pub fn Portal<'a, G: Html>(ctx: Scope<'a>, props: PortalProps<'a, G>) -> View<G> {
     let PortalProps { children, selector } = props;
 
     if G::IS_BROWSER {

--- a/packages/sycamore/src/utils/render.rs
+++ b/packages/sycamore/src/utils/render.rs
@@ -24,7 +24,7 @@ use crate::view::{View, ViewType};
 ///   Even if the node to be inserted is the only child of `parent`, `multi` can still be set to
 ///   `false` but forgoes the optimizations.
 pub fn insert<G: GenericNode>(
-    ctx: ScopeRef<'_>,
+    ctx: Scope<'_>,
     parent: &G,
     accessor: View<G>,
     initial: Option<View<G>>,
@@ -35,7 +35,7 @@ pub fn insert<G: GenericNode>(
 }
 
 fn insert_expression<G: GenericNode>(
-    ctx: ScopeRef<'_>,
+    ctx: Scope<'_>,
     parent: &G,
     value: &View<G>,
     mut current: Option<View<G>>,
@@ -76,7 +76,7 @@ fn insert_expression<G: GenericNode>(
                     value = f.get();
                 }
                 insert_expression(
-                    &ctx,
+                    ctx,
                     &parent,
                     &value,
                     current.clone(),
@@ -100,7 +100,7 @@ fn insert_expression<G: GenericNode>(
                     // This will call normalize_incoming_fragment again, but this time with the
                     // unwrap_fragment arg set to true.
                     insert_expression(
-                        &ctx,
+                        ctx,
                         &parent,
                         &value,
                         current.clone(),

--- a/packages/sycamore/src/view.rs
+++ b/packages/sycamore/src/view.rs
@@ -36,7 +36,7 @@ impl<G: GenericNode> View<G> {
     }
 
     /// Create a new [`View`] from a [`FnMut`].
-    pub fn new_dyn<'a>(ctx: ScopeRef<'a>, mut f: impl FnMut() -> View<G> + 'a) -> Self {
+    pub fn new_dyn<'a>(ctx: Scope<'a>, mut f: impl FnMut() -> View<G> + 'a) -> Self {
         let signal = ctx.create_ref(RefCell::new(None::<RcSignal<View<G>>>));
         ctx.create_effect(move || {
             let view = f();
@@ -53,8 +53,8 @@ impl<G: GenericNode> View<G> {
 
     /// Create a new [`View`] from a [`FnMut`] while creating a new child reactive scope.
     pub fn new_dyn_scoped<'a>(
-        ctx: ScopeRef<'a>,
-        mut f: impl FnMut(BoundedScopeRef<'_, 'a>) -> View<G> + 'a,
+        ctx: Scope<'a>,
+        mut f: impl FnMut(BoundedScope<'_, 'a>) -> View<G> + 'a,
     ) -> Self {
         let signal = ctx.create_ref(RefCell::new(None::<RcSignal<View<G>>>));
         ctx.create_effect_scoped(move |ctx| {

--- a/packages/sycamore/tests/web/builder_hydrate.rs
+++ b/packages/sycamore/tests/web/builder_hydrate.rs
@@ -9,7 +9,7 @@ fn check(actual: &str, expect: Expect) {
 
 mod hello_world {
     use super::*;
-    fn v<G: Html>(ctx: ScopeRef) -> View<G> {
+    fn v<G: Html>(ctx: Scope) -> View<G> {
         h(p).t("Hello World!").view(ctx)
     }
     #[test]
@@ -34,7 +34,7 @@ mod hello_world {
 
 mod hydrate_recursive {
     use super::*;
-    fn v<G: Html>(ctx: ScopeRef) -> View<G> {
+    fn v<G: Html>(ctx: Scope) -> View<G> {
         h(div).c(h(p).t("Nested")).view(ctx)
     }
     #[test]
@@ -59,7 +59,7 @@ mod hydrate_recursive {
 
 mod multiple_nodes_at_same_depth {
     use super::*;
-    fn v<G: Html>(ctx: ScopeRef) -> View<G> {
+    fn v<G: Html>(ctx: Scope) -> View<G> {
         h(div).c(h(p).t("First")).c(h(p).t("Second")).view(ctx)
     }
     #[test]
@@ -86,7 +86,7 @@ mod multiple_nodes_at_same_depth {
 
 mod top_level_fragment {
     use super::*;
-    fn v<G: Html>(ctx: ScopeRef) -> View<G> {
+    fn v<G: Html>(ctx: Scope) -> View<G> {
         fragment([h(p).t("First").view(ctx), h(p).t("Second").view(ctx)])
     }
     #[test]
@@ -111,7 +111,7 @@ mod top_level_fragment {
 
 mod dynamic {
     use super::*;
-    fn v<'a, G: Html>(ctx: ScopeRef<'a>, state: &'a ReadSignal<i32>) -> View<G> {
+    fn v<'a, G: Html>(ctx: Scope<'a>, state: &'a ReadSignal<i32>) -> View<G> {
         h(p).dyn_t(|| state.get().to_string()).view(ctx)
     }
     #[test]
@@ -167,7 +167,7 @@ mod dynamic {
 
 mod dynamic_with_siblings {
     use super::*;
-    fn v<'a, G: Html>(ctx: ScopeRef<'a>, state: &'a ReadSignal<i32>) -> View<G> {
+    fn v<'a, G: Html>(ctx: Scope<'a>, state: &'a ReadSignal<i32>) -> View<G> {
         h(p).t("Value: ")
             .dyn_t(|| state.get().to_string())
             .t("!")
@@ -217,7 +217,7 @@ mod dynamic_with_siblings {
 
 mod dynamic_template {
     use super::*;
-    fn v<'a, G: Html>(ctx: ScopeRef<'a>, state: &'a ReadSignal<View<G>>) -> View<G> {
+    fn v<'a, G: Html>(ctx: Scope<'a>, state: &'a ReadSignal<View<G>>) -> View<G> {
         h(p).t("before")
             .dyn_c(|| state.get().as_ref().clone())
             .t("after")
@@ -268,7 +268,7 @@ mod dynamic_template {
 
 mod top_level_dynamic_with_siblings {
     use super::*;
-    fn v<'a, G: Html>(ctx: ScopeRef<'a>, state: &'a ReadSignal<i32>) -> View<G> {
+    fn v<'a, G: Html>(ctx: Scope<'a>, state: &'a ReadSignal<i32>) -> View<G> {
         fragment([t("Value: "), dyn_t(ctx, || state.get().to_string()), t("!")])
     }
     #[test]

--- a/packages/sycamore/tests/web/cleanup.rs
+++ b/packages/sycamore/tests/web/cleanup.rs
@@ -43,7 +43,7 @@ pub fn test_cleanup_in_effect() {
 }
 
 #[component]
-fn CleanupComp<G: Html>(ctx: ScopeRef) -> View<G> {
+fn CleanupComp<G: Html>(ctx: Scope) -> View<G> {
     ctx.on_cleanup(on_cleanup_callback);
     view! { ctx, }
 }

--- a/packages/sycamore/tests/web/hydrate.rs
+++ b/packages/sycamore/tests/web/hydrate.rs
@@ -8,7 +8,7 @@ fn check(actual: &str, expect: Expect) {
 
 mod hello_world {
     use super::*;
-    fn v<G: Html>(ctx: ScopeRef) -> View<G> {
+    fn v<G: Html>(ctx: Scope) -> View<G> {
         view! { ctx, p { "Hello World!" } }
     }
     #[test]
@@ -33,7 +33,7 @@ mod hello_world {
 
 mod hydrate_recursive {
     use super::*;
-    fn v<G: Html>(ctx: ScopeRef) -> View<G> {
+    fn v<G: Html>(ctx: Scope) -> View<G> {
         view! { ctx, div { p { "Nested" } } }
     }
     #[test]
@@ -58,7 +58,7 @@ mod hydrate_recursive {
 
 mod multiple_nodes_at_same_depth {
     use super::*;
-    fn v<G: Html>(ctx: ScopeRef) -> View<G> {
+    fn v<G: Html>(ctx: Scope) -> View<G> {
         view! { ctx, div { p { "First" } p { "Second" } } }
     }
     #[test]
@@ -85,7 +85,7 @@ mod multiple_nodes_at_same_depth {
 
 mod top_level_fragment {
     use super::*;
-    fn v<G: Html>(ctx: ScopeRef) -> View<G> {
+    fn v<G: Html>(ctx: Scope) -> View<G> {
         view! { ctx, p { "First" } p { "Second" } }
     }
     #[test]
@@ -110,7 +110,7 @@ mod top_level_fragment {
 
 mod dynamic {
     use super::*;
-    fn v<'a, G: Html>(ctx: ScopeRef<'a>, state: &'a ReadSignal<i32>) -> View<G> {
+    fn v<'a, G: Html>(ctx: Scope<'a>, state: &'a ReadSignal<i32>) -> View<G> {
         view! { ctx, p { (state.get()) } }
     }
     #[test]
@@ -166,7 +166,7 @@ mod dynamic {
 
 mod dynamic_with_siblings {
     use super::*;
-    fn v<'a, G: Html>(ctx: ScopeRef<'a>, state: &'a ReadSignal<i32>) -> View<G> {
+    fn v<'a, G: Html>(ctx: Scope<'a>, state: &'a ReadSignal<i32>) -> View<G> {
         view! { ctx, p { "Value: " (state.get()) "!" } }
     }
     #[test]
@@ -213,7 +213,7 @@ mod dynamic_with_siblings {
 
 mod dynamic_template {
     use super::*;
-    fn v<'a, G: Html>(ctx: ScopeRef<'a>, state: &'a ReadSignal<View<G>>) -> View<G> {
+    fn v<'a, G: Html>(ctx: Scope<'a>, state: &'a ReadSignal<View<G>>) -> View<G> {
         view! { ctx, p { "before" (*state.get()) "after" } }
     }
     #[test]
@@ -261,7 +261,7 @@ mod dynamic_template {
 
 mod top_level_dynamic_with_siblings {
     use super::*;
-    fn v<'a, G: Html>(ctx: ScopeRef<'a>, state: &'a ReadSignal<i32>) -> View<G> {
+    fn v<'a, G: Html>(ctx: Scope<'a>, state: &'a ReadSignal<i32>) -> View<G> {
         view! { ctx, "Value: " (state.get()) "!" }
     }
     #[test]

--- a/website/src/content.rs
+++ b/website/src/content.rs
@@ -18,7 +18,7 @@ pub struct Outline {
 }
 
 #[component]
-pub fn OutlineView<G: Html>(ctx: ScopeRef, outline: Vec<Outline>) -> View<G> {
+pub fn OutlineView<G: Html>(ctx: Scope, outline: Vec<Outline>) -> View<G> {
     web_sys::window()
         .unwrap()
         .document()
@@ -77,7 +77,7 @@ pub struct ContentProps {
 
 #[component]
 pub fn Content<G: Html>(
-    ctx: ScopeRef,
+    ctx: Scope,
     ContentProps {
         data: MarkdownPage { html, outline },
         sidebar,

--- a/website/src/header.rs
+++ b/website/src/header.rs
@@ -4,7 +4,7 @@ use crate::sidebar::SidebarData;
 use crate::DarkMode;
 
 #[component]
-fn DarkModeToggle<G: Html>(ctx: ScopeRef) -> View<G> {
+fn DarkModeToggle<G: Html>(ctx: Scope) -> View<G> {
     static LIGHT_BULB_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="lightbulb" class="svg-inline--fa fa-lightbulb fa-w-11" role="img" viewBox="0 0 352 512"><path fill="currentColor" d="M96.06 454.35c.01 6.29 1.87 12.45 5.36 17.69l17.09 25.69a31.99 31.99 0 0 0 26.64 14.28h61.71a31.99 31.99 0 0 0 26.64-14.28l17.09-25.69a31.989 31.989 0 0 0 5.36-17.69l.04-38.35H96.01l.05 38.35zM0 176c0 44.37 16.45 84.85 43.56 115.78 16.52 18.85 42.36 58.23 52.21 91.45.04.26.07.52.11.78h160.24c.04-.26.07-.51.11-.78 9.85-33.22 35.69-72.6 52.21-91.45C335.55 260.85 352 220.37 352 176 352 78.61 272.91-.3 175.45 0 73.44.31 0 82.97 0 176zm176-80c-44.11 0-80 35.89-80 80 0 8.84-7.16 16-16 16s-16-7.16-16-16c0-61.76 50.24-112 112-112 8.84 0 16 7.16 16 16s-7.16 16-16 16z"/></svg>"#;
     static CLOUD_MOON_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="far" data-icon="moon" class="svg-inline--fa fa-moon fa-w-16" role="img" viewBox="0 0 512 512"><path fill="currentColor" d="M279.135 512c78.756 0 150.982-35.804 198.844-94.775 28.27-34.831-2.558-85.722-46.249-77.401-82.348 15.683-158.272-47.268-158.272-130.792 0-48.424 26.06-92.292 67.434-115.836 38.745-22.05 28.999-80.788-15.022-88.919A257.936 257.936 0 0 0 279.135 0c-141.36 0-256 114.575-256 256 0 141.36 114.576 256 256 256zm0-464c12.985 0 25.689 1.201 38.016 3.478-54.76 31.163-91.693 90.042-91.693 157.554 0 113.848 103.641 199.2 215.252 177.944C402.574 433.964 344.366 464 279.135 464c-114.875 0-208-93.125-208-208s93.125-208 208-208z"/></svg>"#;
 
@@ -23,7 +23,7 @@ fn DarkModeToggle<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-fn Nav<G: Html>(ctx: ScopeRef) -> View<G> {
+fn Nav<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         // css hack: use pseudo elements to make nested backdrop filters work
         nav(class="after:absolute after:z-neg after:top-0 after:left-0 after:right-0 after:bottom-0 \
@@ -60,7 +60,7 @@ fn Nav<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-pub fn NavLinks<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn NavLinks<G: Html>(ctx: Scope) -> View<G> {
     static LINK_CLASS: &str =
         "py-2 px-4 text-sm hover:text-gray-800 dark:hover:text-gray-100 hover:underline";
     view! { ctx,
@@ -73,7 +73,7 @@ pub fn NavLinks<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-pub fn HamburgerMenu<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn HamburgerMenu<G: Html>(ctx: Scope) -> View<G> {
     static HAMBURGER_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="bars" class="svg-inline--fa fa-bars fa-w-14" role="img" viewBox="0 0 448 512"><path fill="currentColor" d="M16 132h416c8.837 0 16-7.163 16-16V76c0-8.837-7.163-16-16-16H16C7.163 60 0 67.163 0 76v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16zm0 160h416c8.837 0 16-7.163 16-16v-40c0-8.837-7.163-16-16-16H16c-8.837 0-16 7.163-16 16v40c0 8.837 7.163 16 16 16z"/></svg>"#;
     static CLOSE_SVG: &str = r#"<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="times" class="svg-inline--fa fa-times fa-w-11" role="img" viewBox="0 0 352 512"><path fill="currentColor" d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"/></svg>"#;
 
@@ -120,7 +120,7 @@ pub fn HamburgerMenu<G: Html>(ctx: ScopeRef) -> View<G> {
 }
 
 #[component]
-pub fn Header<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn Header<G: Html>(ctx: Scope) -> View<G> {
     view! { ctx,
         header(class="fixed top-0 z-50 w-full") {
             Nav {}

--- a/website/src/index.rs
+++ b/website/src/index.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-pub fn Index<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn Index<G: Html>(ctx: Scope) -> View<G> {
     web_sys::window()
         .unwrap()
         .document()

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -63,12 +63,12 @@ async fn get_sidebar(version: Option<&str>) -> SidebarData {
     }
 }
 
-fn switch<'a, G: Html>(ctx: ScopeRef<'a>, route: &'a ReadSignal<Routes>) -> View<G> {
+fn switch<'a, G: Html>(ctx: Scope<'a>, route: &'a ReadSignal<Routes>) -> View<G> {
     let cached_sidebar_data =
         ctx.create_ref(create_rc_signal(None::<(Option<String>, SidebarData)>));
     ctx.provide_context_ref(cached_sidebar_data);
 
-    let fetch_docs_data = |url| {
+    let fetch_docs_data = move |url| {
         let data = ctx.create_resource(docs_preload(url));
         if cached_sidebar_data.get().is_none()
             || cached_sidebar_data.get().as_ref().as_ref().unwrap().0 != None
@@ -169,7 +169,7 @@ fn switch<'a, G: Html>(ctx: ScopeRef<'a>, route: &'a ReadSignal<Routes>) -> View
 }
 
 #[component]
-fn App<G: Html>(ctx: ScopeRef) -> View<G> {
+fn App<G: Html>(ctx: Scope) -> View<G> {
     let local_storage = web_sys::window().unwrap().local_storage().unwrap();
     // Get dark mode from media query.
     let dark_mode_mq = web_sys::window()

--- a/website/src/news_index.rs
+++ b/website/src/news_index.rs
@@ -24,7 +24,7 @@ static POSTS: &[(&str, &str, &str)] = &[
 ];
 
 #[component]
-pub fn NewsIndex<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn NewsIndex<G: Html>(ctx: Scope) -> View<G> {
     web_sys::window()
         .unwrap()
         .document()

--- a/website/src/sidebar.rs
+++ b/website/src/sidebar.rs
@@ -19,7 +19,7 @@ pub struct SidebarData {
 }
 
 #[component]
-pub fn Sidebar<G: Html>(ctx: ScopeRef, (version, data): (String, SidebarData)) -> View<G> {
+pub fn Sidebar<G: Html>(ctx: Scope, (version, data): (String, SidebarData)) -> View<G> {
     let sections = data
         .sections
         .into_iter()

--- a/website/src/versions.rs
+++ b/website/src/versions.rs
@@ -30,7 +30,7 @@ const VERSIONS: &[(&str, VersionedDocsLink)] = &[
 
 #[component]
 fn VersionedDocsLink<G: Html>(
-    ctx: ScopeRef,
+    ctx: Scope,
     (name, versioned_docs_link): (&'static str, &'static VersionedDocsLink),
 ) -> View<G> {
     match versioned_docs_link {
@@ -73,7 +73,7 @@ fn VersionedDocsLink<G: Html>(
 }
 
 #[component]
-pub fn Versions<G: Html>(ctx: ScopeRef) -> View<G> {
+pub fn Versions<G: Html>(ctx: Scope) -> View<G> {
     web_sys::window()
         .unwrap()
         .document()


### PR DESCRIPTION
Also renames `ScopeRef` to `Scope` and `BoundedScopeRef` to `BoundedScope`. The methods are now implemented on `BoundedScope` instead of `Scope` so that deref on `BoundedScope` is no longer needed.