### PR TITLE
Clearlify specify behavior of GenericNode::add_class to split multiple classes at whitespace

### DIFF
--- a/packages/sycamore-reactive/src/arena.rs
+++ b/packages/sycamore-reactive/src/arena.rs
@@ -33,8 +33,8 @@ impl<'a> ScopeArena<'a> {
         // - It is allocated on the heap and therefore has a stable address.
         // - self.inner is append only. That means that the Box<_> will not be dropped until Self is
         //   dropped.
-        // - The drop code for Scope never reads the allocated value and therefore does not
-        //   create a stacked-borrows violation.
+        // - The drop code for Scope never reads the allocated value and therefore does not create a
+        //   stacked-borrows violation.
         unsafe { &*ptr }
     }
 

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -175,10 +175,7 @@ where
 /// The sycamore router component. This component expects to be used inside a browser environment.
 /// For server environments, see [`StaticRouter`].
 #[component]
-pub fn Router<'a, G: Html, R, F, I>(
-    ctx: Scope<'a>,
-    props: RouterProps<'a, R, F, I, G>,
-) -> View<G>
+pub fn Router<'a, G: Html, R, F, I>(ctx: Scope<'a>, props: RouterProps<'a, R, F, I, G>) -> View<G>
 where
     R: Route + 'a,
     F: FnOnce(Scope<'a>, &'a ReadSignal<R>) -> View<G> + 'a,

--- a/packages/sycamore/src/generic_node/dom_node.rs
+++ b/packages/sycamore/src/generic_node/dom_node.rs
@@ -6,6 +6,7 @@ use std::cell::Cell;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
+use js_sys::Array;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::{intern, JsCast};
 use web_sys::{Comment, Document, Element, Node, Text};
@@ -207,11 +208,20 @@ impl GenericNode for DomNode {
     }
 
     fn add_class(&self, class: &str) {
-        self.node
-            .unchecked_ref::<Element>()
-            .class_list()
-            .add_1(class)
-            .unwrap_throw();
+        let class_list = class.split_ascii_whitespace().collect::<Vec<_>>();
+        if class_list.len() == 1 {
+            self.node
+                .unchecked_ref::<Element>()
+                .class_list()
+                .add_1(class_list[0])
+                .unwrap_throw();
+        } else {
+            self.node
+                .unchecked_ref::<Element>()
+                .class_list()
+                .add(&class_list.into_iter().map(JsValue::from).collect::<Array>())
+                .unwrap_throw();
+        }
     }
 
     fn remove_class(&self, class: &str) {

--- a/packages/sycamore/src/generic_node/mod.rs
+++ b/packages/sycamore/src/generic_node/mod.rs
@@ -99,6 +99,8 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
     fn set_class_name(&self, value: &str);
 
     /// Add a class to the element.
+    /// If multiple classes are specified, delimited by spaces, all the classes should be added.
+    /// Any classes that are already present should not be added a second time.
     fn add_class(&self, class: &str);
 
     /// Remove a class from the element.

--- a/packages/sycamore/src/generic_node/ssr_node.rs
+++ b/packages/sycamore/src/generic_node/ssr_node.rs
@@ -310,12 +310,7 @@ impl GenericNode for SsrNode {
             .remove_child(self);
     }
 
-    fn event<'a>(
-        &self,
-        _ctx: Scope<'a>,
-        _name: &str,
-        _handler: Box<dyn Fn(Self::EventType) + 'a>,
-    ) {
+    fn event<'a>(&self, _ctx: Scope<'a>, _name: &str, _handler: Box<dyn Fn(Self::EventType) + 'a>) {
         // Noop. Events are attached on client side.
     }
 


### PR DESCRIPTION
Fixes #365 