### PR TITLE
Simplify SsrNode and HydrateNode codegen in view! macro

### DIFF
--- a/packages/sycamore-macro/src/view/codegen.rs
+++ b/packages/sycamore-macro/src/view/codegen.rs
@@ -131,7 +131,6 @@ impl Codegen {
                     };
                     let marker_or_none = marker_is_some.then(|| marker.clone()).unwrap_or_default();
 
-                    // If __el is a HydrateNode, use get_next_marker as initial node value.
                     let initial = quote! { ::sycamore::utils::initial_node(&__el) };
                     let ssr_markers = quote! {
                         ::sycamore::generic_node::GenericNode::append_child(

--- a/packages/sycamore-macro/src/view/codegen.rs
+++ b/packages/sycamore-macro/src/view/codegen.rs
@@ -132,21 +132,7 @@ impl Codegen {
                     let marker_or_none = marker_is_some.then(|| marker.clone()).unwrap_or_default();
 
                     // If __el is a HydrateNode, use get_next_marker as initial node value.
-                    let initial = if cfg!(feature = "experimental-hydrate") {
-                        quote! {
-                            if let ::std::option::Option::Some(__el)
-                                = <dyn ::std::any::Any>::downcast_ref::<::sycamore::generic_node::HydrateNode>(&__el) {
-                                let __initial = ::sycamore::utils::hydrate::web::get_next_marker(&__el.inner_element());
-                                // Do not drop the HydrateNode because it will be cast into a GenericNode.
-                                let __initial = ::std::mem::ManuallyDrop::new(__initial);
-                                // SAFETY: This is safe because we already checked that the type is HydrateNode.
-                                // __initial is wrapped inside ManuallyDrop to prevent double drop.
-                                unsafe { ::std::ptr::read(&__initial as *const _ as *const _) }
-                            } else { ::std::option::Option::None }
-                        }
-                    } else {
-                        quote! { ::std::option::Option::None }
-                    };
+                    let initial = quote! { ::sycamore::utils::initial_node(&__el) };
                     let ssr_markers = quote! {
                         ::sycamore::generic_node::GenericNode::append_child(
                             &__el,

--- a/packages/sycamore/src/utils/mod.rs
+++ b/packages/sycamore/src/utils/mod.rs
@@ -12,14 +12,14 @@ pub mod hydrate;
 pub mod render;
 
 /// If `el` is a `HydrateNode`, use `get_next_marker` to get the initial node value.
-pub fn initial_node<G: GenericNode>(el: &G) -> Option<View<G>> {
+pub fn initial_node<G: GenericNode>(_el: &G) -> Option<View<G>> {
     #[cfg(feature = "experimental-hydrate")]
     {
         use crate::generic_node::HydrateNode;
         use std::any::Any;
         use std::mem::ManuallyDrop;
         use std::ptr;
-        if let Some(el) = <dyn Any>::downcast_ref::<HydrateNode>(el) {
+        if let Some(el) = <dyn Any>::downcast_ref::<HydrateNode>(_el) {
             let initial = hydrate::web::get_next_marker(&el.inner_element());
             // Do not drop the HydrateNode because it will be cast into a GenericNode.
             let initial = ManuallyDrop::new(initial);

--- a/packages/sycamore/src/utils/mod.rs
+++ b/packages/sycamore/src/utils/mod.rs
@@ -4,6 +4,34 @@
 //! This API is considered implementation details and should not at any time be considered stable.
 //! The API can change without warning and without a semver compatible release.
 
+use crate::generic_node::GenericNode;
+use crate::prelude::View;
+
 #[cfg(feature = "experimental-hydrate")]
 pub mod hydrate;
 pub mod render;
+
+/// If `el` is a `HydrateNode`, use `get_next_marker` to get the initial node value.
+pub fn initial_node<G: GenericNode>(el: &G) -> Option<View<G>> {
+    #[cfg(feature = "experimental-hydrate")]
+    {
+        use crate::generic_node::HydrateNode;
+        use std::any::Any;
+        use std::mem::ManuallyDrop;
+        use std::ptr;
+        if let Some(el) = <dyn Any>::downcast_ref::<HydrateNode>(el) {
+            let initial = hydrate::web::get_next_marker(&el.inner_element());
+            // Do not drop the HydrateNode because it will be cast into a GenericNode.
+            let initial = ManuallyDrop::new(initial);
+            // SAFETY: This is safe because we already checked that the type is HydrateNode.
+            // initial is wrapped inside ManuallyDrop to prevent double drop.
+            unsafe { ptr::read(&initial as *const _ as *const _) }
+        } else {
+            None
+        }
+    }
+    #[cfg(not(feature = "experimental-hydrate"))]
+    {
+        None
+    }
+}


### PR DESCRIPTION
Fixes exponential code generation when using SSR and hydration with the `view!` macro.
Also fixes hydration errors related to the fact that code in client side is not executed in the same order as on the server side.