### PR TITLE
Allow field init shorthand for component prop fields

### DIFF
--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -1,5 +1,17 @@
 use sycamore::prelude::*;
 
+#[derive(Prop)]
+pub struct Prop {
+    prop: &'static str,
+}
+
+#[component]
+pub fn PropComponent<G: Html>(cx: Scope, Prop { prop }: Prop) -> View<G> {
+    view! { cx,
+        div
+    }
+}
+
 #[component]
 pub fn Component<G: Html>(cx: Scope) -> View<G> {
     view! { cx,
@@ -10,6 +22,10 @@ pub fn Component<G: Html>(cx: Scope) -> View<G> {
 fn compile_pass<G: Html>() {
     create_scope_immediate(|cx| {
         let _: View<G> = view! { cx, Component() };
+
+        let prop = "prop";
+        let _: View<G> = view! { cx, PropComponent { prop: prop } };
+        let _: View<G> = view! { cx, PropComponent { prop } };
     });
 }
 


### PR DESCRIPTION
Adds support for field init shorthand syntax, with tests.
 
```rust
let signal = create_signal(cx, 0);
view! { cx, Component { signal } }
```