### PR TITLE
Fix some macro edge cases and improve macro hygiene/diagnostics

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,8 @@ jobs:
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
         env:
           RUN_UI_TESTS: true
+          # We don't want the UI tests to fail because of mismatches in compile errors
+          TRYBUILD: wip
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           RUN_UI_TESTS: true
           # We don't want the UI tests to fail because of mismatches in compile errors
-          TRYBUILD: wip
+          TRYBUILD: overwrite
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        env:
+          RUN_UI_TESTS: true
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/packages/sycamore-macro/Cargo.toml
+++ b/packages/sycamore-macro/Cargo.toml
@@ -20,7 +20,7 @@ quote = "1.0.15"
 syn = { version = "1.0.86", features = ["extra-traits", "full"] }
 
 [dev-dependencies]
-sycamore = { path = "../sycamore", features = ["hydrate"] }
+sycamore = { path = "../sycamore", features = ["hydrate", "suspense"] }
 trybuild = "1.0.56"
 
 [features]

--- a/packages/sycamore-macro/src/component/mod.rs
+++ b/packages/sycamore-macro/src/component/mod.rs
@@ -139,8 +139,8 @@ impl ToTokens for ComponentFunction {
                     #[allow(non_snake_case)]
                     #inner_sig #block
 
-                    let __dyn = create_signal(#cx, ::sycamore::view::View::empty());
-                    let __view = ::sycamore::view! { #cx, (__dyn.get().as_ref().clone()) };
+                    let __dyn = ::sycamore::reactive::create_signal(#cx, ::sycamore::view::View::empty());
+                    let __view = ::sycamore::view::View::new_dyn(#cx, || <_ as ::std::clone::Clone>::clone(&*__dyn.get()));
 
                     ::sycamore::suspense::suspense_scope(#cx, async move {
                         let __async_view = #inner_ident(#(#args),*).await;

--- a/packages/sycamore-macro/src/component/mod.rs
+++ b/packages/sycamore-macro/src/component/mod.rs
@@ -3,9 +3,11 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    parse_quote, Expr, FnArg, Item, ItemFn, Pat, Result, ReturnType, Signature, Type, TypeTuple,
+    parse_quote, Expr, FnArg, Item, ItemFn, Pat, Result, ReturnType, Signature, Token, Type,
+    TypeTuple,
 };
 
 pub struct ComponentFunction {
@@ -52,7 +54,12 @@ impl Parse for ComponentFunction {
 
                 if inputs.len() > 2 {
                     return Err(syn::Error::new(
-                        sig.inputs.span(),
+                        sig.inputs
+                            .clone()
+                            .into_iter()
+                            .skip(2)
+                            .collect::<Punctuated<_, Token![,]>>()
+                            .span(),
                         "component should not take more than 2 arguments",
                     ));
                 }
@@ -68,7 +75,7 @@ impl Parse for ComponentFunction {
                     if let Type::Tuple(TypeTuple { elems, .. }) = &*pat.ty {
                         if elems.is_empty() {
                             return Err(syn::Error::new(
-                                elems.span(),
+                                pat.ty.span(),
                                 "taking an unit tuple as props is useless",
                             ));
                         }

--- a/packages/sycamore-macro/src/component/mod.rs
+++ b/packages/sycamore-macro/src/component/mod.rs
@@ -36,8 +36,8 @@ impl Parse for ComponentFunction {
 
                 if let ReturnType::Default = sig.output {
                     return Err(syn::Error::new(
-                        sig.span(),
-                        "function must return `sycamore::view::View`",
+                        sig.paren_token.span,
+                        "component must return `sycamore::view::View`",
                     ));
                 };
 
@@ -45,7 +45,7 @@ impl Parse for ComponentFunction {
 
                 if inputs.is_empty() {
                     return Err(syn::Error::new(
-                        sig.inputs.span(),
+                        sig.paren_token.span,
                         "component must take at least one argument of type `sycamore::reactive::Scope`",
                     ));
                 }
@@ -84,7 +84,7 @@ impl Parse for ComponentFunction {
             }
             item => Err(syn::Error::new_spanned(
                 item,
-                "`component` attribute can only be applied to functions",
+                "the `component` attribute can only be applied to functions",
             )),
         }
     }

--- a/packages/sycamore-macro/src/view/ir.rs
+++ b/packages/sycamore-macro/src/view/ir.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use once_cell::sync::Lazy;
-use proc_macro2::{TokenStream, TokenTree};
+use proc_macro2::{TokenStream, TokenTree, Span};
 use quote::ToTokens;
 use syn::punctuated::Punctuated;
 use syn::{Expr, Ident, LitStr, Path, Token};
@@ -58,6 +58,7 @@ pub enum ElementTag {
 pub struct Attribute {
     pub ty: AttributeType,
     pub value: Expr,
+    pub span: Span,
 }
 
 #[derive(PartialEq, Eq)]

--- a/packages/sycamore-macro/src/view/ir.rs
+++ b/packages/sycamore-macro/src/view/ir.rs
@@ -3,7 +3,7 @@
 use std::collections::HashSet;
 
 use once_cell::sync::Lazy;
-use proc_macro2::{TokenStream, TokenTree, Span};
+use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::ToTokens;
 use syn::punctuated::Punctuated;
 use syn::{Expr, Ident, LitStr, Path, Token};

--- a/packages/sycamore-macro/src/view/parse.rs
+++ b/packages/sycamore-macro/src/view/parse.rs
@@ -88,11 +88,13 @@ impl Parse for Element {
             let dangerously_set_inner_html_span = attrs.iter().find_map(|attr| {
                 (attr.ty == AttributeType::DangerouslySetInnerHtml).then(|| attr.span)
             });
-            if dangerously_set_inner_html_span.is_some() && !body.is_empty() {
-                return Err(syn::Error::new(
-                    dangerously_set_inner_html_span.unwrap(),
-                    content.error("children and dangerously_set_inner_html cannot be both set"),
-                ));
+            if let Some(span) = dangerously_set_inner_html_span {
+                if !body.is_empty() {
+                    return Err(syn::Error::new(
+                        span,
+                        content.error("children and dangerously_set_inner_html cannot be both set"),
+                    ));
+                }
             }
 
             body

--- a/packages/sycamore-macro/src/view/parse.rs
+++ b/packages/sycamore-macro/src/view/parse.rs
@@ -83,17 +83,22 @@ impl Parse for Element {
             while !content.is_empty() {
                 body.push(content.parse()?);
             }
+
+            // Check if dangerously_set_inner_html is also set.
+            let dangerously_set_inner_html_span = attrs.iter().find_map(|attr| {
+                (attr.ty == AttributeType::DangerouslySetInnerHtml).then(|| attr.span)
+            });
+            if dangerously_set_inner_html_span.is_some() && !body.is_empty() {
+                return Err(syn::Error::new(
+                    dangerously_set_inner_html_span.unwrap(),
+                    content.error("children and dangerously_set_inner_html cannot be both set"),
+                ));
+            }
+
             body
         } else {
             Vec::new()
         };
-
-        let has_dangerously_set_inner_html_attr = attrs
-            .iter()
-            .any(|attr| attr.ty == AttributeType::DangerouslySetInnerHtml);
-        if has_dangerously_set_inner_html_attr && !children.is_empty() {
-            return Err(input.error("children and dangerously_set_inner_html cannot be both set"));
-        }
 
         Ok(Self {
             tag,
@@ -128,10 +133,11 @@ impl Parse for ElementTag {
 
 impl Parse for Attribute {
     fn parse(input: ParseStream) -> Result<Self> {
+        let span = input.span();
         let ty = input.parse()?;
         let _eqs: Token![=] = input.parse()?;
         let value = input.parse()?;
-        Ok(Self { ty, value })
+        Ok(Self { ty, value, span })
     }
 }
 

--- a/packages/sycamore-macro/tests/component/component-fail.rs
+++ b/packages/sycamore-macro/tests/component/component-fail.rs
@@ -2,31 +2,32 @@ use sycamore::prelude::*;
 
 /// Missing return type.
 #[component]
-fn comp1<G: Html>() {
+fn Comp1<G: Html>(_cx: Scope) {
+    todo!();
+}
+
+// Missing cx param.
+#[component]
+fn Comp2<G: Html>() -> View<G> {
     todo!();
 }
 
 #[component]
-async fn comp2<G: Html>() -> View<G> {
+const fn Comp3<G: Html>(_cx: Scope) -> View<G> {
     todo!();
 }
 
 #[component]
-const fn comp3<G: Html>() -> View<G> {
+extern fn Comp4<G: Html>(_cx: Scope) -> View<G> {
     todo!();
 }
 
 #[component]
-extern fn comp4<G: Html>() -> View<G> {
+fn Comp5<G: Html>(self) -> View<G> {
     todo!();
 }
 
 #[component]
-fn comp5<G: Html>(self) -> View<G> {
-    todo!();
-}
-
-#[component]
-struct Comp7;
+struct Comp6;
 
 fn main() {}

--- a/packages/sycamore-macro/tests/component/component-fail.rs
+++ b/packages/sycamore-macro/tests/component/component-fail.rs
@@ -30,4 +30,16 @@ fn Comp5<G: Html>(self) -> View<G> {
 #[component]
 struct Comp6;
 
+#[component]
+fn CompWithMultipleProps<G: Html>(_cx: Scope, prop1: ::std::primitive::i32, prop2: ::std::primitive::i32) -> View<G> {
+    let _ = prop1;
+    let _ = prop2;
+    ::std::todo!();
+}
+
+#[component]
+fn CompWithUnitProps<G: Html>(_cx: Scope, prop: ()) -> View<G> {
+    ::std::todo!();
+}
+
 fn main() {}

--- a/packages/sycamore-macro/tests/component/component-fail.stderr
+++ b/packages/sycamore-macro/tests/component/component-fail.stderr
@@ -1,37 +1,35 @@
-error: function must return `sycamore::view::View`
- --> tests/component/component-fail.rs:5:1
+error: component must return `sycamore::view::View`
+ --> tests/component/component-fail.rs:5:18
   |
-5 | fn comp1<G: Html>() {
-  | ^^
+5 | fn Comp1<G: Html>(_cx: Scope) {
+  |                  ^^^^^^^^^^^^
 
 error: component must take at least one argument of type `sycamore::reactive::Scope`
- --> tests/component/component-fail.rs:9:1
-  |
-9 | #[component]
-  | ^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `component` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> tests/component/component-fail.rs:11:18
+   |
+11 | fn Comp2<G: Html>() -> View<G> {
+   |                  ^^
 
 error: const functions can't be components
-  --> tests/component/component-fail.rs:15:1
+  --> tests/component/component-fail.rs:16:1
    |
-15 | const fn comp3<G: Html>() -> View<G> {
+16 | const fn Comp3<G: Html>(_cx: Scope) -> View<G> {
    | ^^^^^
 
 error: extern functions can't be components
-  --> tests/component/component-fail.rs:20:1
+  --> tests/component/component-fail.rs:21:1
    |
-20 | extern fn comp4<G: Html>() -> View<G> {
+21 | extern fn Comp4<G: Html>(_cx: Scope) -> View<G> {
    | ^^^^^^
 
 error: function components can't accept a receiver
-  --> tests/component/component-fail.rs:25:19
+  --> tests/component/component-fail.rs:26:19
    |
-25 | fn comp5<G: Html>(self) -> View<G> {
+26 | fn Comp5<G: Html>(self) -> View<G> {
    |                   ^^^^
 
-error: `component` attribute can only be applied to functions
-  --> tests/component/component-fail.rs:30:1
+error: the `component` attribute can only be applied to functions
+  --> tests/component/component-fail.rs:31:1
    |
-30 | struct Comp7;
+31 | struct Comp6;
    | ^^^^^^^^^^^^^

--- a/packages/sycamore-macro/tests/component/component-fail.stderr
+++ b/packages/sycamore-macro/tests/component/component-fail.stderr
@@ -33,3 +33,15 @@ error: the `component` attribute can only be applied to functions
    |
 31 | struct Comp6;
    | ^^^^^^^^^^^^^
+
+error: component should not take more than 2 arguments
+  --> tests/component/component-fail.rs:34:77
+   |
+34 | fn CompWithMultipleProps<G: Html>(_cx: Scope, prop1: ::std::primitive::i32, prop2: ::std::primitive::i32) -> View<G> {
+   |                                                                             ^^^^^
+
+error: taking an unit tuple as props is useless
+  --> tests/component/component-fail.rs:41:49
+   |
+41 | fn CompWithUnitProps<G: Html>(_cx: Scope, prop: ()) -> View<G> {
+   |                                                 ^^

--- a/packages/sycamore-macro/tests/component/component-pass.rs
+++ b/packages/sycamore-macro/tests/component/component-pass.rs
@@ -11,4 +11,9 @@ fn Comp2<G: Html>(_cx: Scope) -> View<G> {
     ::std::todo!();
 }
 
+#[component]
+async fn AsyncComponent1<G: Html>(_cx: Scope<'_>) -> View<G> {
+    ::std::todo!();
+}
+
 fn main() {}

--- a/packages/sycamore-macro/tests/component/component-pass.rs
+++ b/packages/sycamore-macro/tests/component/component-pass.rs
@@ -1,13 +1,14 @@
-use sycamore::prelude::*;
+#![no_implicit_prelude]
+use ::sycamore::prelude::{component, Html, Scope, View};
 
 #[component]
-fn comp1<G: Html>(_cx: Scope) -> View<G> {
-    todo!();
+fn Comp1<G: Html>(_cx: Scope) -> View<G> {
+    ::std::todo!();
 }
 
 #[component]
-fn comp2<G: Html>(_cx: Scope) -> View<G> {
-    todo!();
+fn Comp2<G: Html>(_cx: Scope) -> View<G> {
+    ::std::todo!();
 }
 
 fn main() {}

--- a/packages/sycamore-macro/tests/component/component-pass.rs
+++ b/packages/sycamore-macro/tests/component/component-pass.rs
@@ -2,17 +2,24 @@
 use ::sycamore::prelude::{component, Html, Scope, View};
 
 #[component]
-fn Comp1<G: Html>(_cx: Scope) -> View<G> {
+fn CompNoProps<G: Html>(_cx: Scope) -> View<G> {
     ::std::todo!();
 }
 
 #[component]
-fn Comp2<G: Html>(_cx: Scope) -> View<G> {
+fn CompWithProps<G: Html>(_cx: Scope, prop: ::std::primitive::i32) -> View<G> {
+    let _ = prop;
     ::std::todo!();
 }
 
 #[component]
-async fn AsyncComponent1<G: Html>(_cx: Scope<'_>) -> View<G> {
+async fn AsyncCompNoProps<G: Html>(_cx: Scope<'_>) -> View<G> {
+    ::std::todo!();
+}
+
+#[component]
+async fn AsyncCompWithProps<G: Html>(_cx: Scope<'_>, prop: ::std::primitive::i32) -> View<G> {
+    let _ = prop;
     ::std::todo!();
 }
 

--- a/packages/sycamore-macro/tests/view/component-fail.rs
+++ b/packages/sycamore-macro/tests/view/component-fail.rs
@@ -1,7 +1,7 @@
 use sycamore::prelude::*;
 
 #[component]
-fn c(cx: Scope) -> View<G> {
+fn C<G: Html>(cx: Scope) -> View<G> {
     view! {
         div
     }
@@ -10,6 +10,7 @@ fn c(cx: Scope) -> View<G> {
 fn compile_fail<G: Html>() {
     create_scope_immediate(|cx| {
         let _: View<G> = view! { cx, UnknownComponent() };
+        let _: View<G> = view! { cx, UnknownComponent {} };
 
         let _: View<G> = view! { cx, C };
         let _: View<G> = view! { cx, C(1) };

--- a/packages/sycamore-macro/tests/view/component-fail.stderr
+++ b/packages/sycamore-macro/tests/view/component-fail.stderr
@@ -9,20 +9,12 @@ error: unexpected end of input, expected `,` (help: make sure you pass the cx va
   = note: this error originates in the macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of input, expected either `(` or `{`
-  --> tests/view/component-fail.rs:14:26
+  --> tests/view/component-fail.rs:15:26
    |
-14 |         let _: View<G> = view! { cx, C };
+15 |         let _: View<G> = view! { cx, C };
    |                          ^^^^^^^^^^^^^^^
    |
    = note: this error originates in the macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error[E0412]: cannot find type `G` in this scope
- --> tests/view/component-fail.rs:4:25
-  |
-4 | fn c(cx: Scope) -> View<G> {
-  |     -                   ^ not found in this scope
-  |     |
-  |     help: you might be missing a type parameter: `<G>`
 
 error[E0425]: cannot find function, tuple struct or tuple variant `UnknownComponent` in this scope
   --> tests/view/component-fail.rs:12:38
@@ -30,20 +22,14 @@ error[E0425]: cannot find function, tuple struct or tuple variant `UnknownCompon
 12 |         let _: View<G> = view! { cx, UnknownComponent() };
    |                                      ^^^^^^^^^^^^^^^^ not found in this scope
 
-error[E0425]: cannot find function, tuple struct or tuple variant `C` in this scope
-  --> tests/view/component-fail.rs:15:38
+error[E0425]: cannot find function, tuple struct or tuple variant `UnknownComponent` in this scope
+  --> tests/view/component-fail.rs:13:38
    |
-4  | fn c(cx: Scope) -> View<G> {
-   | -------------------------- similarly named function `c` defined here
-...
-15 |         let _: View<G> = view! { cx, C(1) };
-   |                                      ^
+13 |         let _: View<G> = view! { cx, UnknownComponent {} };
+   |                                      ^^^^^^^^^^^^^^^^ not found in this scope
+
+error[E0308]: mismatched types
+  --> tests/view/component-fail.rs:16:40
    |
-help: a function with a similar name exists
-   |
-15 |         let _: View<G> = view! { cx, c(1) };
-   |                                      ~
-help: you might be missing a type parameter
-   |
-10 | fn compile_fail<G: Html, C>() {
-   |                        +++
+16 |         let _: View<G> = view! { cx, C(1) };
+   |                                        ^ expected `()`, found integer

--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -6,7 +6,7 @@ pub struct Prop {
 }
 
 #[component]
-pub fn PropComponent<G: Html>(cx: Scope, Prop { prop }: Prop) -> View<G> {
+pub fn PropComponent<G: Html>(cx: Scope, Prop { prop: _ }: Prop) -> View<G> {
     view! { cx,
         div
     }

--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -22,6 +22,7 @@ pub fn Component<G: Html>(cx: Scope) -> View<G> {
 fn compile_pass<G: Html>() {
     create_scope_immediate(|cx| {
         let _: View<G> = view! { cx, Component() };
+        let _: View<G> = view! { cx, Component {} };
 
         let prop = "prop";
         let _: View<G> = view! { cx, PropComponent { prop: prop } };

--- a/packages/sycamore-macro/tests/view/element-fail.stderr
+++ b/packages/sycamore-macro/tests/view/element-fail.stderr
@@ -23,17 +23,10 @@ error: expected `=`
    |                                              ^
 
 error: unexpected end of input, children and dangerously_set_inner_html cannot be both set
-  --> tests/view/element-fail.rs:12:26
+  --> tests/view/element-fail.rs:13:15
    |
-12 |           let _: View<G> = view! { cx,
-   |  __________________________^
-13 | |             p(dangerously_set_inner_html="<span>Test</span>") {
-14 | |                 "Error"
-15 | |             }
-16 | |         };
-   | |_________^
-   |
-   = note: this error originates in the macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
+13 |             p(dangerously_set_inner_html="<span>Test</span>") {
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0412]: cannot find type `unknownelement` in module `sycamore::html`
  --> tests/view/element-fail.rs:8:38


### PR DESCRIPTION
Notable changes:
- Fixes macro hygiene when using async components.
- Adds `#![no_implicit_prelude]` to certain UI tests.
- Improves `#[component]` macro diagnostic spans.
- Adds additional UI tests for `#[component]`.
- Include UI tests in coverage reports.