### PR TITLE
Handle parsing of component children with function-like syntax

### DIFF
--- a/packages/sycamore-macro/src/view/parse.rs
+++ b/packages/sycamore-macro/src/view/parse.rs
@@ -226,7 +226,7 @@ impl Parse for Component {
             while !content.is_empty() {
                 let fork = content.fork();
                 if let Ok(value) = fork.parse() {
-                    if fork.peek(Brace) {
+                    if fork.peek(Brace) || ViewNode::peek_type(&fork).is_some() {
                         break;
                     }
                     content.advance_to(&fork);

--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -12,6 +12,16 @@ pub fn PropComponent<G: Html>(cx: Scope, Prop { prop: _ }: Prop) -> View<G> {
     }
 }
 
+#[derive(Prop)]
+pub struct PropWithChildren<'a, G: GenericNode> {
+    children: Children<'a, G>,
+}
+
+#[component]
+pub fn ComponentWithChildren<'a, G: Html>(cx: Scope<'a>, prop: PropWithChildren<'a, G>) -> View<G> {
+    prop.children.call(cx)
+}
+
 #[component]
 pub fn Component<G: Html>(cx: Scope) -> View<G> {
     view! { cx,
@@ -27,6 +37,18 @@ fn compile_pass<G: Html>() {
         let prop = "prop";
         let _: View<G> = view! { cx, PropComponent { prop: prop } };
         let _: View<G> = view! { cx, PropComponent { prop } };
+
+        let _: View<G> = view! { cx,
+            ComponentWithChildren {
+                Component()
+            }
+        };
+
+        let _: View<G> = view! { cx,
+            ComponentWithChildren {
+                Component {}
+            }
+        };
     });
 }
 


### PR DESCRIPTION
The parsing logic for components in a view was missing a check for children using function-like calling.

Before this commit, the following snippet would compile:
```rust
view! { cx, Component { Child {} } }
view! { cx, Component { div {} } }
```

...while this would not:
```rust
view! { cx, Component { Child() } }
view! { cx, Component { div() } }
```
<br>
Tests are added to ensure that either way of calling a component compiles.