### PR TITLE
Add the http-request-builder example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "examples/context",
   "examples/counter",
   "examples/http-request",
+  "examples/http-request-builder",
   "examples/hydrate",
   "examples/iteration",
   "examples/js-framework-benchmark",

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,7 @@ Now open up `localhost:8080` in your browser to see "Hello World!".
 | [hello-world](hello-world)                         | Hello World!                                                                                   |
 | [higher-order-components](higher-order-components) | Higher-order-components (functions that create components)                                     |
 | [http-request](http-request)                       | Suspense + async components for sending HTTP requests                                          |
+| [http-request-builder](http-request-builder)       | Suspense + async components for sending HTTP requests using the builder API!                   |
 | [hydrate](hydrate)                                 | Making existing HTML reactive                                                                  |
 | [iteration](iteration)                             | Demonstration of how to iterate over data in UI                                                |
 | [js-framework-benchmark](js-framework-benchmark)   | Implementation of [js-framework-benchmark](https://github.com/krausest/js-framework-benchmark) |

--- a/examples/http-request-builder/Cargo.toml
+++ b/examples/http-request-builder/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "http-request-builder"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+console_error_panic_hook = "0.1.7"
+console_log = "0.2.0"
+log = "0.4.14"
+reqwasm = "0.4.1"
+serde = "1.0.136"
+sycamore = { path = "../../packages/sycamore", features = ["suspense", "builder"] }

--- a/examples/http-request-builder/index.html
+++ b/examples/http-request-builder/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>HTTP Request | Sycamore Builder Syntax</title>
+    <title>HTTP Request - Builder API | Sycamore</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
   </head>
   <body></body>

--- a/examples/http-request-builder/index.html
+++ b/examples/http-request-builder/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>HTTP Request | Sycamore Builder Syntax</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body></body>
+</html>

--- a/examples/http-request-builder/src/main.rs
+++ b/examples/http-request-builder/src/main.rs
@@ -1,0 +1,56 @@
+use reqwasm::http::Request;
+use serde::{Deserialize, Serialize};
+use sycamore::builder::prelude::*;
+use sycamore::component::Prop;
+use sycamore::prelude::*;
+use sycamore::suspense::{Suspense, SuspenseProps};
+
+// API that counts visits to the web-page
+const API_BASE_URL: &str = "https://api.countapi.xyz/hit";
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+struct Visits {
+    value: u64,
+}
+
+async fn fetch_visits(id: &str) -> Result<Visits, reqwasm::Error> {
+    let url = format!("{}/{}/hits", API_BASE_URL, id);
+    let resp = Request::get(&url).send().await?;
+
+    let body = resp.json::<Visits>().await?;
+    Ok(body)
+}
+
+#[component]
+async fn VisitsCount<G: Html>(cx: Scope<'_>) -> View<G> {
+    let id = "sycamore-builder-visits-counter";
+    let visits = fetch_visits(id).await.unwrap_or_default();
+
+    h(p).t("Total Visits: ")
+        .c(h(span).dyn_t(move || visits.value.to_string()))
+        .view(cx)
+}
+
+#[component]
+fn App<G: Html>(cx: Scope) -> View<G> {
+    h(div)
+        .c(h(p).t("Page Visit Counter"))
+        .c(Suspense(
+            cx,
+            // Take advantage that structs that derive Prop have public builders even
+            // if the fields are private and come from a different crate (in this case the Sycamore
+            // crate).
+            SuspenseProps::builder()
+                .fallback(t("Loading"))
+                .children(Children::new(cx, |cx| VisitsCount(cx, ())))
+                .build(),
+        ))
+        .view(cx)
+}
+
+fn main() {
+    console_error_panic_hook::set_once();
+    console_log::init_with_level(log::Level::Debug).unwrap();
+
+    sycamore::render(|cx| App(cx, ()));
+}


### PR DESCRIPTION
This adds the same example as the `http-request` but using the builder
syntax.

Most of the code is the same and a fair degree of the change from macro
to builder syntax is trivial. Using `Suspense` with the builder syntax
does not seem to be covered in the documentation. This also shows off that structs
that derive `Prop` have public builders which may be required using the
builder syntax - such as with `SuspenseProps`.

I added a comment to the `SuspenseProps` part just because I don't think it is obvious
or documented (on the website) that by deriving `Prop` you get a free typed builder too :)

I know @lukechu10 spoke about changing the API around Suspense in the builder
syntax on Discord - so I'm aware you might have reason to not accept this PR yet (or at all) if
those changes are coming soon.

Closes #395