### PR TITLE
Fix destructuring async props

### DIFF
--- a/packages/sycamore-macro/src/component/mod.rs
+++ b/packages/sycamore-macro/src/component/mod.rs
@@ -106,7 +106,6 @@ impl Parse for ComponentFunction {
 
 struct AsyncCompInputs {
     cx: syn::Ident,
-    // only expect one input (i.e. prop struct) but Punctuated ready to add to Signature.
     sync_input: Punctuated<FnArg, syn::token::Comma>,
     async_args: Vec<Expr>,
 }

--- a/packages/sycamore-macro/src/component/mod.rs
+++ b/packages/sycamore-macro/src/component/mod.rs
@@ -143,11 +143,13 @@ fn async_comp_inputs_from_sig_inputs(
         unreachable!("We check in parsing that the first argument is not a receiver");
     };
 
-    let prop_arg = inputs.next().map(|x| match x {
+    // In parsing we checked that there were two args so we can unwrap here.
+    let prop_fn_arg = inputs.next().unwrap();
+    let prop_arg = match prop_fn_arg {
         FnArg::Typed(t) => match &*t.pat {
-            Pat::Ident(id) => pat_ident_arm(&mut sync_input, x, id),
+            Pat::Ident(id) => pat_ident_arm(&mut sync_input, prop_fn_arg, id),
             Pat::Wild(_) => {
-                sync_input.push(x.clone());
+                sync_input.push(prop_fn_arg.clone());
                 parse_quote!(())
             }
             Pat::Struct(pat_struct) => {
@@ -181,11 +183,9 @@ fn async_comp_inputs_from_sig_inputs(
             _ => panic!("unexpected pattern!"),
         },
         FnArg::Receiver(_) => unreachable!(),
-    });
+    };
 
-    // In parsing we checked that there were two args and so the second arg can either
-    // be a Some or would have panic'd so we are safe to unwrap here.
-    async_args.push(prop_arg.unwrap());
+    async_args.push(prop_arg);
 
     AsyncCompInputs {
         cx,

--- a/packages/sycamore-macro/src/component/mod.rs
+++ b/packages/sycamore-macro/src/component/mod.rs
@@ -64,9 +64,16 @@ impl Parse for ComponentFunction {
                     ));
                 }
 
-                if let FnArg::Receiver(arg) = &inputs[0] {
+                if let FnArg::Typed(t) = &inputs[0] {
+                    if !matches!(&*t.pat, Pat::Ident(_)) {
+                        return Err(syn::Error::new(
+                            t.span(),
+                            "First argument to a component is expected to be a `sycamore::reactive::Scope`",
+                        ));
+                    }
+                } else {
                     return Err(syn::Error::new(
-                        arg.span(),
+                        inputs[0].span(),
                         "function components can't accept a receiver",
                     ));
                 }
@@ -97,6 +104,96 @@ impl Parse for ComponentFunction {
     }
 }
 
+struct AsyncCompInputs {
+    cx: syn::Ident,
+    // only expect one input (i.e. prop struct) but Punctuated ready to add to Signature.
+    sync_input: Punctuated<FnArg, syn::token::Comma>,
+    async_args: Vec<Expr>,
+}
+
+fn async_comp_inputs_from_sig_inputs(
+    inputs: &Punctuated<FnArg, syn::token::Comma>,
+) -> AsyncCompInputs {
+    let mut sync_input = Punctuated::new();
+    let mut async_args = Vec::with_capacity(2);
+
+    #[inline]
+    fn pat_ident_arm(
+        sync_input: &mut Punctuated<FnArg, syn::token::Comma>,
+        fn_arg: &FnArg,
+        id: &syn::PatIdent,
+    ) -> syn::Expr {
+        sync_input.push(fn_arg.clone());
+        let ident = &id.ident;
+        parse_quote! { #ident }
+    }
+
+    let mut inputs = inputs.iter();
+
+    let cx_fn_arg = inputs.next().unwrap();
+
+    let cx = if let FnArg::Typed(t) = cx_fn_arg {
+        if let Pat::Ident(id) = &*t.pat {
+            async_args.push(pat_ident_arm(&mut sync_input, cx_fn_arg, id));
+            id.ident.clone()
+        } else {
+            unreachable!("We check in parsing that the first argument is a Ident");
+        }
+    } else {
+        unreachable!("We check in parsing that the first argument is not a receiver");
+    };
+
+    let prop_arg = inputs.next().map(|x| match x {
+        FnArg::Typed(t) => match &*t.pat {
+            Pat::Ident(id) => pat_ident_arm(&mut sync_input, x, id),
+            Pat::Wild(_) => {
+                sync_input.push(x.clone());
+                parse_quote!(())
+            }
+            Pat::Struct(pat_struct) => {
+                // For the sync input we don't want a destructured pattern but just to take a
+                // `syn::PatType` (i.e. `props: MyPropStruct`) then the inner async function
+                // signature can have the destructured pattern and it will work correctly
+                // aslong as we provide our brand new ident that we used in the
+                // `syn::PatIdent`.
+                let ident = syn::Ident::new("props", pat_struct.span());
+                // props are taken by value so no refs or mutability required here
+                // The destructured pattern can add mutability (if required) even without this
+                // set.
+                let pat_ident = syn::PatIdent {
+                    attrs: vec![],
+                    by_ref: None,
+                    mutability: None,
+                    ident,
+                    subpat: None,
+                };
+                let pat_type = syn::PatType {
+                    attrs: vec![],
+                    pat: Box::new(Pat::Ident(pat_ident)),
+                    colon_token: Default::default(),
+                    ty: t.ty.clone(),
+                };
+
+                let fn_arg = FnArg::Typed(pat_type);
+                sync_input.push(fn_arg);
+                parse_quote! { props }
+            }
+            _ => panic!("unexpected pattern!"),
+        },
+        FnArg::Receiver(_) => unreachable!(),
+    });
+
+    // In parsing we checked that there were two args and so the second arg can either
+    // be a Some or would have panic'd so we are safe to unwrap here.
+    async_args.push(prop_arg.unwrap());
+
+    AsyncCompInputs {
+        cx,
+        async_args,
+        sync_input,
+    }
+}
+
 impl ToTokens for ComponentFunction {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let ComponentFunction { f } = self;
@@ -108,36 +205,33 @@ impl ToTokens for ComponentFunction {
         } = &f;
 
         if sig.asyncness.is_some() {
+            // When the component function is async then we need to extract out some of the
+            // function signature (Syn::Signature) so that we can wrap the async function with
+            // a non-async component.
+            //
+            // In order to support the struct destructured pattern for props we alter the existing
+            // signature for the non-async component so that it is defined as a `Syn::PatType`
+            // (i.e. props: MyPropStruct) with a new `Syn::Ident` "props". We then use this ident
+            // again as an argument to the inner async function which has the user defined
+            // destructured pattern which will work as expected.
+            //
+            // Note: that the change to the signature is not semantically different to a would be caller.
             let inputs = &sig.inputs;
-            let args: Vec<Expr> = inputs
-                .iter()
-                .map(|x| match x {
-                    FnArg::Typed(t) => match &*t.pat {
-                        Pat::Ident(id) => {
-                            let id = &id.ident;
-                            parse_quote! { #id }
-                        }
-                        Pat::Wild(_) => parse_quote!(()),
-                        _ => panic!("unexpected pattern"), // TODO
-                    },
-                    FnArg::Receiver(_) => unreachable!(),
-                })
-                .collect::<Vec<_>>();
+            let AsyncCompInputs {
+                cx,
+                sync_input,
+                async_args: args,
+            } = async_comp_inputs_from_sig_inputs(inputs);
+
             let non_async_sig = Signature {
                 asyncness: None,
+                inputs: sync_input,
                 ..sig.clone()
             };
             let inner_ident = format_ident!("{}_inner", sig.ident);
             let inner_sig = Signature {
                 ident: inner_ident.clone(),
                 ..sig.clone()
-            };
-            let cx = match inputs.first().unwrap() {
-                FnArg::Typed(t) => match &*t.pat {
-                    Pat::Ident(id) => &id.ident,
-                    _ => unreachable!(),
-                },
-                FnArg::Receiver(_) => unreachable!(),
             };
             tokens.extend(quote! {
                 #[allow(non_snake_case)]

--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -12,6 +12,13 @@ pub fn PropComponent<G: Html>(cx: Scope, Prop { prop: _ }: Prop) -> View<G> {
     }
 }
 
+#[component]
+async fn AsyncPropComponent<G: Html>(cx: Scope<'_>, Prop { prop: _ }: Prop) -> View<G> {
+    view! { cx,
+        div
+    }
+}
+
 #[derive(Prop)]
 pub struct PropWithChildren<'a, G: GenericNode> {
     children: Children<'a, G>,

--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -12,13 +12,6 @@ pub fn PropComponent<G: Html>(cx: Scope, Prop { prop: _ }: Prop) -> View<G> {
     }
 }
 
-#[component]
-async fn AsyncPropComponent<G: Html>(cx: Scope<'_>, Prop { prop: _ }: Prop) -> View<G> {
-    view! { cx,
-        div
-    }
-}
-
 #[derive(Prop)]
 pub struct PropWithChildren<'a, G: GenericNode> {
     children: Children<'a, G>,
@@ -27,6 +20,14 @@ pub struct PropWithChildren<'a, G: GenericNode> {
 #[component]
 pub fn ComponentWithChildren<'a, G: Html>(cx: Scope<'a>, prop: PropWithChildren<'a, G>) -> View<G> {
     prop.children.call(cx)
+}
+
+#[component]
+pub fn AsyncComponentWithPropDestructuring<'a, G: Html>(
+    cx: Scope<'a>,
+    PropWithChildren { children }: PropWithChildren<'a, G>,
+) -> View<G> {
+    children.call(cx)
 }
 
 #[component]
@@ -53,6 +54,12 @@ fn compile_pass<G: Html>() {
 
         let _: View<G> = view! { cx,
             ComponentWithChildren {
+                Component {}
+            }
+        };
+
+        let _: View<G> = view! { cx,
+            AsyncComponentWithPropDestructuring {
                 Component {}
             }
         };

--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -23,7 +23,7 @@ pub fn ComponentWithChildren<'a, G: Html>(cx: Scope<'a>, prop: PropWithChildren<
 }
 
 #[component]
-pub fn AsyncComponentWithPropDestructuring<'a, G: Html>(
+pub async fn AsyncComponentWithPropDestructuring<'a, G: Html>(
     cx: Scope<'a>,
     PropWithChildren { children }: PropWithChildren<'a, G>,
 ) -> View<G> {


### PR DESCRIPTION
Fixes #410

This PR fixes support in the `#[component]` macro for destructured struct patterns of props.

I added a single test to trybuild using the existing prop struct with generics and lifetimes to show it handles those too :)

I started trying to do what I think was [discussed here](https://github.com/sycamore-rs/sycamore/issues/410#issuecomment-1101893839) only to find that trying to match on fields that themselves might also be destructured was a rabbit hole I didn't want to go down :)

So instead this change simply alters the new sync function that we create to wrap around the async one - it takes the type from the destructured pattern and converts it into a `syn::PatType` (i.e. `props: MyProps`) then we just have to add this ident to the args we supply the async function and the pattern the user uses will work if valid and all the errors associated with incorrect patterns will be well formed from rustc.

I added the more eager parser check for the first argument to be `syn::Ident` instead of the unwrap that was there before as this should give a better error message that will be consistent across both types of components.

Moved most of the change to its own function as it got bit messy and used a struct for named fields so it is hopefully more clear :)