### PR TITLE
Add support for `body`

### DIFF
--- a/examples/http-request-builder/src/main.rs
+++ b/examples/http-request-builder/src/main.rs
@@ -17,7 +17,7 @@ async fn fetch_visits(id: &str) -> Result<Visits, reqwasm::Error> {
     let url = format!("{}/{}/hits", API_BASE_URL, id);
     let resp = Request::get(&url).send().await?;
 
-    Ok(resp.json::<Visits>().await?)
+    resp.json::<Visits>().await
 }
 
 #[component]

--- a/examples/http-request-builder/src/main.rs
+++ b/examples/http-request-builder/src/main.rs
@@ -17,8 +17,7 @@ async fn fetch_visits(id: &str) -> Result<Visits, reqwasm::Error> {
     let url = format!("{}/{}/hits", API_BASE_URL, id);
     let resp = Request::get(&url).send().await?;
 
-    let body = resp.json::<Visits>().await?;
-    Ok(body)
+    Ok(resp.json::<Visits>().await?)
 }
 
 #[component]

--- a/packages/sycamore/src/html/mod.rs
+++ b/packages/sycamore/src/html/mod.rs
@@ -55,6 +55,7 @@ define_elements! {
     bdi {},
     bdo {},
     blockquote {},
+    body {},
     br {},
     /// The `<button>` HTML element represents a clickable button, used to submit forms or anywhere in a document for accessible, standard button functionality.
     ///


### PR DESCRIPTION
This just lets users use the `body` element. I'm not at all familiar with this part of the codebase, so please let me know if there's anything else I need to do to make this work.

Once this is merged, a new beta release would be greatly appreciated so that Perseus can take advantage of this as soon as possible!