### PR TITLE
Use create_ref instead of on_cleanup for allocating event handlers

### DIFF
--- a/packages/sycamore-reactive/src/effect.rs
+++ b/packages/sycamore-reactive/src/effect.rs
@@ -89,7 +89,7 @@ fn _create_effect<'a>(cx: Scope<'a>, f: &'a mut (dyn FnMut() + 'a)) {
                 // Push the effect onto the effect stack so that it is visible by signals.
                 effects
                     .borrow_mut()
-                    .push(unsafe { std::mem::transmute(&mut tmp_effect as *mut EffectState<'a>) });
+                    .push((&mut tmp_effect as *mut EffectState<'a>).cast::<EffectState<'static>>());
                 // Now we can call the user-provided function.
                 f();
                 // Pop the effect from the effect stack.

--- a/packages/sycamore-web/src/dom_node.rs
+++ b/packages/sycamore-web/src/dom_node.rs
@@ -329,14 +329,10 @@ impl GenericNode for DomNode {
         // preventing the handler from ever being accessed after its lifetime.
         let handler: Box<dyn FnMut(Self::EventType) + 'static> =
             unsafe { std::mem::transmute(boxed) };
-        let closure = Closure::wrap(handler);
+        let closure = create_ref(cx, Closure::wrap(handler));
         self.node
             .add_event_listener_with_callback(intern(name), closure.as_ref().unchecked_ref())
             .unwrap_throw();
-
-        on_cleanup(cx, move || {
-            drop(closure);
-        });
     }
 
     fn update_inner_text(&self, text: &str) {


### PR DESCRIPTION
Also simplifies the implementation for `DomNode::event`.