### PR TITLE
Some performance tweaks

### DIFF
--- a/packages/sycamore-reactive/Cargo.toml
+++ b/packages/sycamore-reactive/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/sycamore-rs/sycamore"
 version = "0.8.0-beta.6"
 
 [dependencies]
+ahash = "0.7.6"
 bumpalo = { version = "3.9.1", features = ["boxed"] }
 indexmap = "1.8.0"
 serde = { version = "1.0.136", optional = true }

--- a/packages/sycamore-reactive/src/arena.rs
+++ b/packages/sycamore-reactive/src/arena.rs
@@ -14,7 +14,7 @@ impl<T> ReallyAny for T {}
 
 #[derive(Default)]
 pub(crate) struct ScopeArena<'a> {
-    pub bump: Bump,
+    bump: Bump,
     // We need to store the raw pointers because otherwise the values won't be dropped.
     inner: UnsafeCell<SmallVec<[*mut (dyn ReallyAny + 'a); SCOPE_ARENA_STACK_SIZE]>>,
 }

--- a/packages/sycamore-reactive/src/effect.rs
+++ b/packages/sycamore-reactive/src/effect.rs
@@ -1,6 +1,6 @@
 //! Side effects.
 
-use std::collections::HashSet;
+use ahash::AHashSet;
 
 use crate::*;
 
@@ -17,7 +17,7 @@ pub(crate) struct EffectState<'a> {
     /// The callback when the effect is re-executed.
     cb: Rc<RefCell<dyn FnMut() + 'a>>,
     /// A list of dependencies that can trigger this effect.
-    dependencies: HashSet<EffectDependency>,
+    dependencies: AHashSet<EffectDependency>,
 }
 
 /// Implements reference equality for [`WeakSignalEmitter`]s.
@@ -122,7 +122,7 @@ fn _create_effect<'a>(cx: Scope<'a>, f: &'a mut (dyn FnMut() + 'a)) {
     // Initialize initial effect state.
     *effect.borrow_mut() = Some(EffectState {
         cb: cb.clone(),
-        dependencies: HashSet::new(),
+        dependencies: AHashSet::new(),
     });
 
     // Initial callback call to get everything started.

--- a/packages/sycamore-reactive/src/effect.rs
+++ b/packages/sycamore-reactive/src/effect.rs
@@ -153,7 +153,7 @@ pub fn create_effect_scoped<'a, F>(cx: Scope<'a>, mut f: F)
 where
     F: for<'child_lifetime> FnMut(BoundedScope<'child_lifetime, 'a>) + 'a,
 {
-    let mut disposer: Option<Box<ScopeDisposer<'a>>> = None;
+    let mut disposer: Option<ScopeDisposer<'a>> = None;
     create_effect(cx, move || {
         // We run the disposer inside the effect, after effect dependencies have been cleared.
         // This is to make sure that if the effect subscribes to its own signal, there is no
@@ -163,12 +163,11 @@ where
             unsafe { disposer.dispose() };
         }
         // Create a new nested scope and save the disposer.
-        let new_disposer: Option<Box<ScopeDisposer<'a>>> =
-            Some(Box::new(create_child_scope(cx, |cx| {
-                // SAFETY: f takes the same parameter as the argument to
-                // self.create_child_scope(_).
-                f(unsafe { std::mem::transmute(cx) });
-            })));
+        let new_disposer: Option<ScopeDisposer<'a>> = Some(create_child_scope(cx, |cx| {
+            // SAFETY: f takes the same parameter as the argument to
+            // self.create_child_scope(_).
+            f(unsafe { std::mem::transmute(cx) });
+        }));
         disposer = new_disposer;
     });
 }

--- a/packages/sycamore-reactive/src/iter.rs
+++ b/packages/sycamore-reactive/src/iter.rs
@@ -1,11 +1,12 @@
 //! Reactive utilities for dealing with lists and iterables.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::hash::Hash;
 use std::mem;
 use std::mem::MaybeUninit;
 use std::rc::Rc;
+
+use ahash::AHashMap;
 
 use crate::*;
 
@@ -121,7 +122,7 @@ where
 
             // 0) Prepare a map of indices in newItems. Scan backwards so we encounter them in
             // natural order.
-            let mut new_indices = HashMap::with_capacity(new_end - start);
+            let mut new_indices = AHashMap::with_capacity(new_end - start);
 
             // Indexes for new_indices_next are shifted by start because values at 0..start are
             // always None.

--- a/packages/sycamore-reactive/src/iter.rs
+++ b/packages/sycamore-reactive/src/iter.rs
@@ -1,9 +1,7 @@
 //! Reactive utilities for dealing with lists and iterables.
 
-use std::cell::RefCell;
 use std::hash::Hash;
 use std::mem;
-use std::mem::MaybeUninit;
 use std::rc::Rc;
 
 use ahash::AHashMap;
@@ -34,8 +32,6 @@ where
     K: Eq + Hash,
     U: Clone + 'a,
 {
-    let map_fn = Rc::new(map_fn);
-
     // Previous state used for diffing.
     let mut items = Rc::new(Vec::new());
     let mut mapped: Vec<U> = Vec::new();
@@ -58,17 +54,12 @@ where
             // Fast path for new create.
             // TODO: do not clone T
             for new_item in new_items.iter().cloned() {
-                let tmp = Rc::new(RefCell::new(None));
-                let new_disposer = create_child_scope(cx, {
-                    let tmp = Rc::clone(&tmp);
-                    let map_fn = Rc::clone(&map_fn);
-                    move |cx| {
-                        // SAFETY: f takes the same parameter as the argument to
-                        // create_child_scope(cx, (_).
-                        *tmp.borrow_mut() = Some(map_fn(unsafe { mem::transmute(cx) }, new_item));
-                    }
+                let mut tmp = None;
+                let new_disposer = create_child_scope(cx, |cx| {
+                    // SAFETY: f takes the same parameter as the argument to create_child_scope.
+                    tmp = Some(map_fn(unsafe { mem::transmute(cx) }, new_item));
                 });
-                mapped.push(tmp.borrow().clone().unwrap());
+                mapped.push(tmp.unwrap());
                 disposers.push(Some(new_disposer));
             }
         } else {
@@ -166,24 +157,17 @@ where
                     }
                 } else {
                     // Create new value.
-                    let tmp = Rc::new(RefCell::new(None));
-                    let new_disposer = create_child_scope(cx, {
-                        let tmp = Rc::clone(&tmp);
-                        let map_fn = Rc::clone(&map_fn);
-                        let new_item = new_items[j].clone();
-                        move |cx| {
-                            // SAFETY: f takes the same parameter as the argument to
-                            // create_child_scope.
-                            *tmp.borrow_mut() =
-                                Some(map_fn(unsafe { mem::transmute(cx) }, new_item));
-                        }
+                    let mut tmp = None;
+                    let new_item = new_items[j].clone();
+                    let new_disposer = create_child_scope(cx, |cx| {
+                        // SAFETY: f takes the same parameter as the argument to create_child_scope.
+                        tmp = Some(map_fn(unsafe { mem::transmute(cx) }, new_item));
                     });
-
                     if mapped.len() > j {
-                        mapped[j] = tmp.borrow().clone().unwrap();
+                        mapped[j] = tmp.unwrap();
                         disposers[j] = Some(new_disposer);
                     } else {
-                        mapped.push(tmp.borrow().clone().unwrap());
+                        mapped.push(tmp.unwrap());
                         disposers.push(Some(new_disposer));
                     }
                 }
@@ -229,8 +213,6 @@ where
     T: PartialEq + Clone,
     U: Clone + 'a,
 {
-    let map_fn = Rc::new(map_fn);
-
     // Previous state used for diffing.
     let mut items = Rc::new(Vec::new());
     let mut mapped = Vec::new();
@@ -265,29 +247,20 @@ where
                 // We lift the equality out of the else if branch to satisfy borrow checker.
                 let eqs = item != Some(&new_item);
 
-                let mut tmp = MaybeUninit::<U>::zeroed();
-                let ptr = &mut tmp as *mut MaybeUninit<U>;
+                let mut tmp = None;
                 if item.is_none() || eqs {
-                    let new_disposer = create_child_scope(cx, {
-                        let map_fn = Rc::clone(&map_fn);
-                        move |cx| unsafe {
-                            // SAFETY: callback is called immediately in
-                            // create_child_scope(cx, .
-                            // ptr is still accessible after create_child_scope(cx,  and
-                            // therefore lives long enough.
-
-                            // SAFETY: f takes the same parameter as the argument to
-                            // create_child_scope(cx, (_).
-                            (*ptr).write(map_fn(mem::transmute(cx), new_item));
-                        }
+                    let new_disposer = create_child_scope(cx, |cx| {
+                        // SAFETY: f takes the same parameter as the argument to
+                        // create_child_scope(cx, _).
+                        tmp = Some(map_fn(unsafe { mem::transmute(cx) }, new_item));
                     });
                     if item.is_none() {
-                        // SAFETY: tmp is written in create_child_scope(cx,
-                        mapped.push(unsafe { tmp.assume_init() });
+                        // SAFETY: tmp is written in create_child_scope.
+                        mapped.push(tmp.unwrap());
                         disposers.push(new_disposer);
                     } else if eqs {
-                        // SAFETY: tmp is written in create_child_scope(cx,
-                        mapped[i] = unsafe { tmp.assume_init() };
+                        // SAFETY: tmp is written in create_child_scope.
+                        mapped[i] = tmp.unwrap();
                         let prev = mem::replace(&mut disposers[i], new_disposer);
                         unsafe {
                             prev.dispose();

--- a/packages/sycamore-reactive/src/lib.rs
+++ b/packages/sycamore-reactive/src/lib.rs
@@ -205,8 +205,8 @@ pub fn create_scope<'disposer>(f: impl for<'a> FnOnce(Scope<'a>)) -> ScopeDispos
     // The reference passed to f cannot possible escape the closure. We know however, that ptr
     // necessary outlives the closure call because it is only dropped in the returned disposer
     // closure.
-    untrack(|| f(unsafe { BoundedScope::new(&*ptr) }));
-    //                      ^^^ -> `ptr` is still accessible here after the call to f.
+    untrack(|| f(unsafe { Scope::new(&*ptr) }));
+    //                                 ^^^ -> `ptr` is still accessible here after call to f.
 
     // Ownership of `ptr` is passed into the closure.
     ScopeDisposer::new(move || unsafe {
@@ -286,9 +286,8 @@ where
     // - It is allocated on the heap and therefore has a stable address.
     // - self.child_cx is append only. That means that the Box<cx> will not be dropped until Self is
     //   dropped.
-    f(unsafe { BoundedScope::new(&*ptr) });
-    //                                  ^^^ -> `ptr` is still accessible here after
-    // the call to f.
+    f(unsafe { Scope::new(&*ptr) });
+    //                      ^^^ -> `ptr` is still accessible here after call to f.
     ScopeDisposer::new(move || unsafe {
         let cx = cx.raw.inner.borrow_mut().child_scopes.remove(key).unwrap();
         // SAFETY: Safe because ptr created using Box::into_raw and closure cannot live longer
@@ -368,12 +367,12 @@ impl<'a> ScopeRaw<'a> {
     /// Dropping a [`Scope`] will automatically call [`dispose`](Self::dispose).
     pub(crate) unsafe fn dispose(&self) {
         let mut inner = self.inner.borrow_mut();
-        // Drop child contexts.
-        for &i in mem::take(&mut inner.child_scopes).values() {
+        // Drop child scopes.
+        for &child in mem::take(&mut inner.child_scopes).values() {
             // SAFETY: These pointers were allocated in Self::create_child_scope.
-            let cx = Box::from_raw(i);
+            let cx = Box::from_raw(child);
             // Dispose of cx if it has not already been disposed.
-            cx.dispose()
+            cx.dispose();
         }
         // Call cleanup functions in an untracked scope.
         untrack(|| {
@@ -420,8 +419,7 @@ pub fn on<'a, U, const N: usize>(
         for i in dependencies {
             i.track();
         }
-        #[allow(clippy::redundant_closure)] // Clippy false-positive
-        untrack(|| f())
+        untrack(&mut f)
     }
 }
 

--- a/packages/sycamore-reactive/src/lib.rs
+++ b/packages/sycamore-reactive/src/lib.rs
@@ -11,11 +11,11 @@ mod signal;
 
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::mem;
 use std::rc::{Rc, Weak};
 
+use ahash::AHashMap;
 use arena::*;
 pub use context::*;
 pub use effect::*;
@@ -42,11 +42,11 @@ struct ScopeInner<'a> {
     /// Contexts that are allocated on the current [`Scope`].
     /// See the [`mod@context`] module.
     ///
-    /// Note that the `HashMap` is wrapped with an `Option<Box<_>>`. This is because contexts are
+    /// Note that the `AHashMap` is wrapped with an `Option<Box<_>>`. This is because contexts are
     /// usually read and rarely created. Making this heap allocated when prevent blowing up the
     /// size of the [`ScopeInner`] struct when most of the times, this field is unneeded.
     #[allow(clippy::box_collection)]
-    contexts: Option<Box<HashMap<TypeId, &'a dyn Any>>>,
+    contexts: Option<Box<AHashMap<TypeId, &'a dyn Any>>>,
     // Make sure that 'a is invariant.
     _phantom: InvariantLifetime<'a>,
 }

--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -57,15 +57,18 @@ impl SignalEmitter {
     /// This can be useful when using patterns such as inner mutability where the state updated will
     /// not be automatically triggered. In the general case, however, it is preferable to use
     /// [`Signal::set()`] instead.
+    ///
+    /// This will also re-compute all the subscribers of this signal by calling all the dependency
+    /// callbacks.
     pub fn trigger_subscribers(&self) {
-        // Clone subscribers to prevent modifying list when calling callbacks. We clone into a
-        // `Vec` instead of an `IndexMap` because it is slightly faster.
-        #[allow(clippy::needless_collect)] // Clippy false positive.
-        let subscribers = self.0.borrow().values().cloned().collect::<Vec<_>>();
+        // Reset subscribers to prevent modifying the subscriber list while it is being read from.
+        // We can completely wipe out the subscriber list because it will be constructed again when
+        // each callback is called.
+        let subscribers = self.0.take().into_values();
         // Subscriber order is reversed because effects attach subscribers at the end of the
         // effect scope. This will ensure that outer effects re-execute before inner effects,
         // preventing inner effects from running twice.
-        for subscriber in subscribers.into_iter().rev() {
+        for subscriber in subscribers.rev() {
             // subscriber might have already been destroyed in the case of nested effects.
             if let Some(callback) = subscriber.upgrade() {
                 // Call the callback.

--- a/packages/sycamore-web/src/dom_node.rs
+++ b/packages/sycamore-web/src/dom_node.rs
@@ -75,7 +75,7 @@ impl DomNode {
 
     /// Get the [`NodeId`] for the node.
     pub(super) fn get_node_id(&self) -> NodeId {
-        if self.id.get().0 == 0 {
+        if self.id.get() == NodeId(0) {
             // self.id not yet initialized.
             if let Some(id) = self.node.unchecked_ref::<NodeWithId>().node_id() {
                 self.id.set(NodeId(id));
@@ -286,7 +286,7 @@ impl GenericNode for DomNode {
 
     fn insert_child_before(&self, new_node: &Self, reference_node: Option<&Self>) {
         self.node
-            .insert_before(&new_node.node, reference_node.map(|n| n.node.as_ref()))
+            .insert_before(&new_node.node, reference_node.map(|n| &n.node))
             .unwrap_throw();
     }
 


### PR DESCRIPTION
Optimizations in `sycamore-reactive` crate.

Some notable changes:
- Simplify and reduce allocations in `map_keyed` and `map_indexed`.
- Make `Signal::trigger_subscribers` slightly faster.