### PR TITLE
Fix `scope_depth` to return 0 for root scope

### DIFF
--- a/packages/sycamore-reactive/src/context.rs
+++ b/packages/sycamore-reactive/src/context.rs
@@ -113,6 +113,7 @@ pub fn scope_depth(cx: Scope) -> u32 {
     let mut depth = 0;
     let mut current = cx.raw;
 
+    // SAFETY: 'current.parent' necessarily lives longer than 'current'.
     while let Some(next) = current.parent.map(|x| unsafe { &*x }) {
         current = next;
         depth += 1;

--- a/packages/sycamore-reactive/src/context.rs
+++ b/packages/sycamore-reactive/src/context.rs
@@ -110,11 +110,17 @@ where
 
 /// Returns the current depth of the scope. If the scope is the root scope, returns `0`.
 pub fn scope_depth(cx: Scope) -> u32 {
-    let mut depth = 0;
-    let mut this = Some(cx.raw);
-    while let Some(current) = this {
+    #[inline]
+    fn unchecked_as_ref(x: *const ScopeRaw) -> &ScopeRaw {
         // SAFETY: `current.parent` necessarily lives longer than `current`.
-        this = current.parent.map(|x| unsafe { &*x });
+        unsafe { &*x }
+    }
+
+    let mut depth = 0;
+    let mut next = cx.raw.parent.map(unchecked_as_ref);
+
+    while let Some(current) = next {
+        next = current.parent.map(unchecked_as_ref);
         depth += 1;
     }
     depth

--- a/packages/sycamore-reactive/src/context.rs
+++ b/packages/sycamore-reactive/src/context.rs
@@ -110,17 +110,11 @@ where
 
 /// Returns the current depth of the scope. If the scope is the root scope, returns `0`.
 pub fn scope_depth(cx: Scope) -> u32 {
-    #[inline]
-    fn unchecked_as_ref(x: *const ScopeRaw) -> &ScopeRaw {
-        // SAFETY: `current.parent` necessarily lives longer than `current`.
-        unsafe { &*x }
-    }
-
     let mut depth = 0;
-    let mut next = cx.raw.parent.map(unchecked_as_ref);
+    let mut current = cx.raw;
 
-    while let Some(current) = next {
-        next = current.parent.map(unchecked_as_ref);
+    while let Some(next) = current.parent.map(|x| unsafe { &*x }) {
+        current = next;
         depth += 1;
     }
     depth

--- a/packages/sycamore-reactive/src/context.rs
+++ b/packages/sycamore-reactive/src/context.rs
@@ -183,4 +183,30 @@ mod tests {
             assert_eq!(*b.get(), 123);
         });
     }
+
+    #[test]
+    fn root_scope_is_zero_depth() {
+        create_scope_immediate(|cx| {
+            assert_eq!(scope_depth(cx), 0);
+        });
+    }
+
+    #[test]
+    fn depth_of_scope_inc_with_child_scopes() {
+        create_scope_immediate(|cx| {
+            let _ = create_child_scope(cx, |cx| {
+                // first non root scope should be 1
+                assert_eq!(scope_depth(cx), 1);
+
+                let _ = create_child_scope(cx, |cx| {
+                    // next scope should thus be 2
+                    assert_eq!(scope_depth(cx), 2);
+                });
+
+                // We should still be one out here - not that the current implementation would
+                // suggest otherwise.
+                assert_eq!(scope_depth(cx), 1);
+            });
+        });
+    }
 }


### PR DESCRIPTION
Hi 👋,

Just a quick fix so that the `scope_depth` function returns `0` for the root scope as stated by the comment - 
I also added some tests for the function too.

This function is only ever used in this repository for the following SSR test: https://github.com/sycamore-rs/sycamore/blob/487877f2aee232b4a04c0dd6589a3b2240d292d3/packages/sycamore/tests/ssr/main.rs#L120-L136 
that relies solely on the fact that depth is incremented on child scopes.