### PR TITLE
Remove `builder` feature doc on website

### DIFF
--- a/docs/next/basics/view.md
+++ b/docs/next/basics/view.md
@@ -152,8 +152,7 @@ view! { cx, }
 ## Builder syntax
 
 For those who dislike macro DSLs, we also provide an ergonomic builder API for constructing views.
-To begin, enable the `"builder"` feature flag on `sycamore` in your `Cargo.toml` file. Also make
-sure to add the builder prelude as well as the main sycamore prelude to your source file.
+Add the builder prelude as well as the main sycamore prelude to your source file.
 
 ```rust
 use sycamore::builder::prelude::*;


### PR DESCRIPTION
The `builder` feature flag was removed in #416 but the website still
contained a sentence about adding the feature flag before using the
builder syntax.