### PR TITLE
Fix removing old nodes from parent

### DIFF
--- a/packages/sycamore-core/src/render.rs
+++ b/packages/sycamore-core/src/render.rs
@@ -290,7 +290,7 @@ pub fn reconcile_fragments<G: GenericNode>(parent: &G, a: &mut [G], b: &[G]) {
         } else if b_end == b_start {
             // Remove.
             for node in &a[a_start..a_end] {
-                if map.is_none() || map.as_ref().unwrap().contains_key(node) {
+                if map.is_none() || !map.as_ref().unwrap().contains_key(node) {
                     parent.remove_child(node);
                 }
             }


### PR DESCRIPTION
Fixes #427 

The #427 bug was introduced in #416 inside the `reconcile_fragments` function.

The quick fix was to add the negation that got dropped during that change - this seems
to have caused the bug.

~I instead extracted the removal of nodes from the parent node part of the 
`reconcile_fragments` function to a new function and added tests for this new 
function to avoid any future regressions.~

~The tests use a pretty rough/bare bones mock of a `GenericNode` in order to satisfy the
trait bounds required by the extracted function. I think the tests are worth the added file
noise of the mock but let me know if you'd prefer I remove it (and probably the extracted
function at that point).~
