### PR TITLE
Fix default Unit property on Component

### DIFF
--- a/examples/hello-builder/src/main.rs
+++ b/examples/hello-builder/src/main.rs
@@ -26,5 +26,5 @@ fn main() {
     console_error_panic_hook::set_once();
     console_log::init_with_level(log::Level::Debug).unwrap();
 
-    sycamore::render(|cx| component(|| App(cx, ())));
+    sycamore::render(|cx| component(|| App(cx)));
 }

--- a/examples/higher-order-components/src/main.rs
+++ b/examples/higher-order-components/src/main.rs
@@ -11,8 +11,8 @@ fn MyComponent<G: Html>(cx: Scope, props: i32) -> View<G> {
 
 fn higher_order_component<G: Html>(
     Comp: &dyn Fn(Scope, i32) -> View<G>,
-) -> impl Fn(Scope, ()) -> View<G> + '_ {
-    move |cx, _| {
+) -> impl Fn(Scope) -> View<G> + '_ {
+    move |cx| {
         view! { cx,
             div {
                 Comp(42)

--- a/examples/http-request-builder/src/main.rs
+++ b/examples/http-request-builder/src/main.rs
@@ -41,7 +41,7 @@ fn App<G: Html>(cx: Scope) -> View<G> {
             // crate).
             SuspenseProps::builder()
                 .fallback(t("Loading"))
-                .children(Children::new(cx, |cx| VisitsCount(cx, ())))
+                .children(Children::new(cx, |cx| VisitsCount(cx)))
                 .build(),
         ))
         .view(cx)
@@ -51,5 +51,5 @@ fn main() {
     console_error_panic_hook::set_once();
     console_log::init_with_level(log::Level::Debug).unwrap();
 
-    sycamore::render(|cx| App(cx, ()));
+    sycamore::render(|cx| App(cx));
 }

--- a/packages/sycamore-core/src/component.rs
+++ b/packages/sycamore-core/src/component.rs
@@ -31,21 +31,6 @@ pub trait Prop {
     fn builder() -> Self::Builder;
 }
 
-/* Implement Prop for () */
-
-/// A builder for `()`.
-#[doc(hidden)]
-pub struct UnitBuilder;
-impl UnitBuilder {
-    pub fn build(self) {}
-}
-impl Prop for () {
-    type Builder = UnitBuilder;
-    fn builder() -> Self::Builder {
-        UnitBuilder
-    }
-}
-
 /// Get the builder for the component function.
 #[doc(hidden)]
 pub fn element_like_component_builder<'a, T: Prop + 'a, G: GenericNode>(

--- a/packages/sycamore-macro/src/view/codegen.rs
+++ b/packages/sycamore-macro/src/view/codegen.rs
@@ -4,7 +4,7 @@
 //! of some internal state during the entire codegen.
 
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned};
+use quote::quote;
 use syn::spanned::Spanned;
 use syn::{Expr, ExprLit, Ident, Lit};
 
@@ -447,26 +447,18 @@ impl Codegen {
         match comp {
             Component::FnLike(comp) => {
                 let FnLikeComponent { ident, args } = comp;
-                if args.empty_or_trailing() {
-                    quote! { ::sycamore::component::component_scope(move || #ident(#cx, ())) }
-                } else {
-                    quote! { ::sycamore::component::component_scope(move || #ident(#cx, #args)) }
-                }
+                quote! { ::sycamore::component::component_scope(move || #ident(#cx, #args)) }
             }
             Component::ElementLike(comp) => {
                 let ElementLikeComponent {
                     ident,
-                    brace,
                     props,
                     children,
+                    ..
                 } = comp;
                 if props.is_empty() && children.is_none() {
-                    // If no props, just generate a `()` for props.
-                    // We make sure to give the `()` the same span as the brace tokens for proper
-                    // error spans.
-                    let unit = quote_spanned! { brace.span=> () };
                     quote! {
-                       ::sycamore::component::component_scope(move || #ident(#cx, #unit))
+                       ::sycamore::component::component_scope(move || #ident(#cx))
                     }
                 } else {
                     let mut props_quoted = quote! {

--- a/packages/sycamore-macro/tests/view/component-fail.stderr
+++ b/packages/sycamore-macro/tests/view/component-fail.stderr
@@ -18,25 +18,47 @@ error[E0425]: cannot find function, tuple struct or tuple variant `UnknownCompon
 26 |         let _: View<G> = view! { cx, UnknownComponent {} };
    |                                      ^^^^^^^^^^^^^^^^ not found in this scope
 
-error[E0308]: mismatched types
-  --> tests/view/component-fail.rs:29:48
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> tests/view/component-fail.rs:29:38
    |
 29 |         let _: View<G> = view! { cx, Component(1) };
-   |                                                ^ expected `()`, found integer
+   |                                  --  ^^^^^^^^^ - supplied 2 arguments
+   |                                      |
+   |                                      expected 1 argument
+   |
+note: function defined here
+  --> tests/view/component-fail.rs:17:4
+   |
+17 | fn Component<G: Html>(cx: Scope) -> View<G> {
+   |    ^^^^^^^^^         -
 
-error[E0308]: mismatched types
-  --> tests/view/component-fail.rs:31:26
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+  --> tests/view/component-fail.rs:31:38
    |
 31 |         let _: View<G> = view! { cx, PropComponent() };
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected struct `Prop`, found `()`
+   |                                  --  ^^^^^^^^^^^^^ expected 2 arguments
+   |                                  |
+   |                                  supplied 1 argument
    |
-   = note: this error originates in the macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
+note: function defined here
+  --> tests/view/component-fail.rs:9:8
+   |
+9  | pub fn PropComponent<G: Html>(cx: Scope, Prop { prop: _ }: Prop) -> View<G> {
+   |        ^^^^^^^^^^^^^         ------------
 
-error[E0308]: mismatched types
-  --> tests/view/component-fail.rs:32:52
+error[E0061]: this function takes 2 arguments but 1 argument was supplied
+  --> tests/view/component-fail.rs:32:38
    |
 32 |         let _: View<G> = view! { cx, PropComponent {} };
-   |                                                    ^^ expected struct `Prop`, found `()`
+   |                                  --  ^^^^^^^^^^^^^ expected 2 arguments
+   |                                  |
+   |                                  supplied 1 argument
+   |
+note: function defined here
+  --> tests/view/component-fail.rs:9:8
+   |
+9  | pub fn PropComponent<G: Html>(cx: Scope, Prop { prop: _ }: Prop) -> View<G> {
+   |        ^^^^^^^^^^^^^         ------------
 
 error[E0308]: mismatched types
   --> tests/view/component-fail.rs:33:60

--- a/packages/sycamore/src/builder.rs
+++ b/packages/sycamore/src/builder.rs
@@ -715,7 +715,7 @@ impl<'a, G: Html, F: FnOnce(Scope<'a>) -> G + 'a> ElementBuilder<'a, G, F> {
 ///
 /// // Elsewhere...
 /// # fn view<G: Html>(cx: Scope) -> View<G> {
-/// component(|| MyComponent(cx, ()))
+/// component(|| MyComponent(cx))
 /// # }
 /// ```
 pub fn component<G>(f: impl FnOnce() -> View<G>) -> View<G>


### PR DESCRIPTION
Removes the default `()` unit property when no properties are
specified in the Component definition.

Removes the above assumption in the `view` macro codegen.
Removes the `UnitBuilder` struct and Unit prop impl from `sycamore-core`.

Fixes #415