### PR TITLE
Add a generic `from_web_sys` function

### DIFF
--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -16,6 +16,8 @@ mod hydrate_node;
 #[cfg(feature = "ssr")]
 mod ssr_node;
 
+use std::any::{Any, TypeId};
+
 pub use dom_node::*;
 #[cfg(feature = "hydrate")]
 pub use hydrate_node::*;
@@ -40,8 +42,6 @@ pub trait Html: GenericNode<EventType = Event, PropertyType = JsValue> {
 /// # Panics
 /// When G is not either a `DomNode` or a `HydrateNode`.
 pub fn from_web_sys<G: Html>(node: web_sys::Node) -> G {
-    use std::any::{Any, TypeId};
-
     let type_id = TypeId::of::<G>();
 
     if TypeId::of::<DomNode>() == type_id {
@@ -54,7 +54,7 @@ pub fn from_web_sys<G: Html>(node: web_sys::Node) -> G {
         return (&node as &dyn Any).downcast_ref().cloned().unwrap();
     }
 
-    panic!("Expected GenericNode to either be a DomNode or a HydrateNode");
+    panic!("expected GenericNode to either be a DomNode or a HydrateNode");
 }
 
 /// Queue up a callback to be executed when the component is mounted.


### PR DESCRIPTION
Adds a new function in `sycamore-web` that creates a 
`GenericNode` from a `web_sys::Element` and depending 
on the type will reuse the element in the DOM.

This approach tries to cover the concern of [recreating
existing node](https://github.com/sycamore-rs/sycamore/issues/261#issuecomment-925476447) and returning a `G: GenericNode` that can be used easily.

The function accepts `web_sys::Element` instead of
`web_sys::Node` to avoid having to do error checking
for the case of some non element node. If the user
is using this function then they are probably already
in the know about how to use `JsCast` to get this type
and they can deal with whether they need the overhead
of type checking (in js land anyway).

Not a big fan of the unsafe transmutes in general but 
going the `&dyn Any` downcast route will probably 
effect performance and I think after checking the 
`TypeId` it should be sound. I couldn't really think of
another way of getting over this issue - but if you have
a better way let me know and I'll change it :)

Closes #261 