### PR TITLE
Add support for `struct` `Route`s

### DIFF
--- a/packages/sycamore-router-macro/src/route.rs
+++ b/packages/sycamore-router-macro/src/route.rs
@@ -90,7 +90,6 @@ pub fn route_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                 ));
             }
 
-            // We implement `Default` as well here for the `Router`/`RouterBase` distinction (`Router` needs to pass a default `impl Route` to `RouterBase`)
             Ok(quote! {
                 impl ::sycamore_router::Route for #ty_name {
                     fn match_route(&self, __segments: &[&str]) -> Self {
@@ -98,6 +97,7 @@ pub fn route_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                         #err_quoted
                     }
                 }
+                // We implement `Default` as well here for the `Router`/`RouterBase` distinction (`Router` needs to pass a default `impl Route` to `RouterBase`)
                 impl ::std::default::Default for #ty_name {
                     fn default() -> Self {
                         #error_handler_name

--- a/packages/sycamore-router-macro/src/route.rs
+++ b/packages/sycamore-router-macro/src/route.rs
@@ -98,7 +98,7 @@ pub fn route_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                         #err_quoted
                     }
                 }
-                impl Default for #ty_name {
+                impl ::std::default::Default for #ty_name {
                     fn default() -> Self {
                         #error_handler_name
                     }

--- a/packages/sycamore-router/src/lib.rs
+++ b/packages/sycamore-router/src/lib.rs
@@ -16,20 +16,20 @@ pub use sycamore_router_macro::Route;
 ///
 /// This trait should not be implemented manually. Use the [`Route`](derive@Route) derive macro
 /// instead.
-pub trait Route: Sized {
+pub trait Route: Sized + Default {
     /// Matches a route with the given path segments. Note that in general, empty segments should be
     /// filtered out before passed as an argument.
     ///
     /// It is likely that you are looking for the [`Route::match_path`] method instead.
-    fn match_route(segments: &[&str]) -> Self;
+    fn match_route(&self, segments: &[&str]) -> Self;
 
     /// Matches a route with the given path.
-    fn match_path(path: &str) -> Self {
+    fn match_path(&self, path: &str) -> Self {
         let segments = path
             .split('/')
             .filter(|s| !s.is_empty())
             .collect::<Vec<_>>();
-        Self::match_route(&segments)
+        self.match_route(&segments)
     }
 }
 
@@ -167,14 +167,14 @@ pub trait TryFromSegments: Sized {
     /// Sets the value of the capture variable with the value of `segments`. Returns `false` if
     /// unsuccessful (e.g. parsing error).
     #[must_use]
-    fn try_from_segments(segments: &[&str]) -> Option<Self>;
+    fn try_from_segments(&self, segments: &[&str]) -> Option<Self>;
 }
 
 impl<T> TryFromSegments for Vec<T>
 where
     T: TryFromParam,
 {
-    fn try_from_segments(segments: &[&str]) -> Option<Self> {
+    fn try_from_segments(&self, segments: &[&str]) -> Option<Self> {
         let mut tmp = Vec::with_capacity(segments.len());
         for segment in segments {
             let value = T::try_from_param(segment)?;
@@ -185,8 +185,8 @@ where
 }
 
 impl<T: Route> TryFromSegments for T {
-    fn try_from_segments(segments: &[&str]) -> Option<Self> {
-        Some(T::match_route(segments))
+    fn try_from_segments(&self, segments: &[&str]) -> Option<Self> {
+        Some(self.match_route(segments))
     }
 }
 


### PR DESCRIPTION
This solves a problem I had with Sycamore last year: that `Route` can only be an `enum`, meaning additional custom information can't be easily attached to the router system. Perseus required this, and did a very hacky workaround that both reduced routing performance there and made for some really weird semantics. With arctic-hen7/perseus#151 though, that workaround it no longer feasible, so this makes `Route` be able to be a `struct`, and `match_route` now takes `&self`.

To achieve this, I've broken out the `Router` into a `Router` and a `RouterBase`, with the former being a wrapper around the latter that simply calls it with `R::default()`, which is now derived automatically in `enum`s as the `#[not_found]` route. All tests pass, and I'm pretty sure I've covered everything, but a review to make sure I haven't missed something would be greatly appreciated!

I haven't done anything with `StaticRouter`, which already takes a specific `Route` instance. `RouterBase` now mimics that, and `Router` just abstracts over it (meaning this isn't a breaking change).

Closes #244.