### PR TITLE
Add the `prop:*` directive to the view macro

### DIFF
--- a/docs/next/basics/view.md
+++ b/docs/next/basics/view.md
@@ -118,6 +118,24 @@ view! { cx,
 
 Instead, when displaying user input, use interpolation syntax instead.
 
+### Properties
+
+Properties are set using the `prop:*` directive.
+
+```rust
+view! { cx,
+    input(type="checkbox", prop:indeterminate=true)
+}
+```
+
+There are some properties that do not have an attribute, such as
+`indeterminate` in HTML, which must be set using the `prop:*` directive.
+
+There are a number of properties that have an associated attribute, such as
+`value`, in these cases an attribute is deserialized to become the state of the
+property. Consider using the `prop:*` for these cases when the value expected by
+the element property is not a `string`.
+
 ### Events
 
 Events are attached using the `on:*` directive.

--- a/examples/motion/src/main.rs
+++ b/examples/motion/src/main.rs
@@ -38,8 +38,8 @@ fn Tweened<G: Html>(cx: Scope) -> View<G> {
                 }
                 "#
             }
-            progress(value=progress.get()[0])
-            progress(value=progress.get()[1])
+            progress(prop:value=progress.get()[0])
+            progress(prop:value=progress.get()[1])
 
             button(on:click=|_| progress.set([0.0, 1.0])) { "0%" }
             button(on:click=|_| progress.set([0.25, 0.75])) { "25%" }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -317,7 +317,7 @@ pub fn Item<G: Html>(cx: Scope, todo: RcSignal<Todo>) -> View<G> {
                 view! { cx,
                     input(ref=input_ref,
                         class="edit",
-                        value=todo.get().title.clone(),
+                        prop:value=&todo.get().title,
                         on:blur=move |_| handle_blur(),
                         on:keyup=handle_submit,
                         on:input=handle_input,

--- a/packages/sycamore-macro/src/view/ir.rs
+++ b/packages/sycamore-macro/src/view/ir.rs
@@ -78,6 +78,8 @@ pub enum AttributeType {
     Event { event: String },
     /// Syntax: `bind:<prop>`.
     Bind { prop: String },
+    /// Syntax: `prop:<prop>`.
+    Property { prop: String },
     /// Syntax: `ref`.
     Ref,
 }

--- a/packages/sycamore-macro/src/view/parse.rs
+++ b/packages/sycamore-macro/src/view/parse.rs
@@ -192,6 +192,12 @@ impl Parse for AttributeType {
                         event: event.to_string(),
                     })
                 }
+                "prop" => {
+                    let prop = input.call(Ident::parse_any)?;
+                    Ok(Self::Property {
+                        prop: prop.to_string(),
+                    })
+                }
                 "bind" => {
                     let prop = input.call(Ident::parse_any)?;
                     Ok(Self::Bind {

--- a/packages/sycamore-macro/tests/view/element-fail.rs
+++ b/packages/sycamore-macro/tests/view/element-fail.rs
@@ -4,6 +4,7 @@ fn compile_fail<G: GenericNode>() {
     create_scope_immediate(|cx| {
         let _: View<G> = view! { cx, button(disabled) };
         let _: View<G> = view! { cx, button(on:click) };
+        let _: View<G> = view! { cx, button(prop:disabled) };
         let _: View<G> = view! { cx, button(unknown:directive="123") };
         let _: View<G> = view! { cx, unknownelement };
 

--- a/packages/sycamore-macro/tests/view/element-fail.stderr
+++ b/packages/sycamore-macro/tests/view/element-fail.stderr
@@ -10,26 +10,32 @@ error: expected `=`
 6 |         let _: View<G> = view! { cx, button(on:click) };
   |                                                     ^
 
-error: unknown directive `unknown`
- --> tests/view/element-fail.rs:7:45
+error: expected `=`
+ --> tests/view/element-fail.rs:7:58
   |
-7 |         let _: View<G> = view! { cx, button(unknown:directive="123") };
+7 |         let _: View<G> = view! { cx, button(prop:disabled) };
+  |                                                          ^
+
+error: unknown directive `unknown`
+ --> tests/view/element-fail.rs:8:45
+  |
+8 |         let _: View<G> = view! { cx, button(unknown:directive="123") };
   |                                             ^^^^^^^
 
 error: expected `=`
-  --> tests/view/element-fail.rs:10:46
+  --> tests/view/element-fail.rs:11:46
    |
-10 |         let _: View<G> = view! { cx, button(a.b.c="123") };
+11 |         let _: View<G> = view! { cx, button(a.b.c="123") };
    |                                              ^
 
 error: unexpected end of input, children and dangerously_set_inner_html cannot be both set
-  --> tests/view/element-fail.rs:13:15
+  --> tests/view/element-fail.rs:14:15
    |
-13 |             p(dangerously_set_inner_html="<span>Test</span>") {
+14 |             p(dangerously_set_inner_html="<span>Test</span>") {
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0412]: cannot find type `unknownelement` in module `sycamore::web::html`
- --> tests/view/element-fail.rs:8:38
+ --> tests/view/element-fail.rs:9:38
   |
-8 |         let _: View<G> = view! { cx, unknownelement };
+9 |         let _: View<G> = view! { cx, unknownelement };
   |                                      ^^^^^^^^^^^^^^ not found in `sycamore::web::html`

--- a/packages/sycamore/tests/web/main.rs
+++ b/packages/sycamore/tests/web/main.rs
@@ -328,6 +328,29 @@ fn reactive_attribute() {
 }
 
 #[wasm_bindgen_test]
+fn reactive_property() {
+    create_scope_immediate(|cx| {
+        let indeterminate = create_signal(cx, true);
+
+        let node = view! { cx,
+            input(type="checkbox", prop:indeterminate=*indeterminate.get())
+        };
+
+        sycamore::render_to(|_| node, &test_container());
+        let input: web_sys::HtmlInputElement = document()
+            .query_selector("input")
+            .unwrap()
+            .unwrap()
+            .unchecked_into();
+
+        assert!(input.indeterminate());
+
+        indeterminate.set(false);
+        assert!(!input.indeterminate());
+    });
+}
+
+#[wasm_bindgen_test]
 #[ignore]
 fn two_way_bind_to_props() {
     create_scope_immediate(|cx| {

--- a/packages/sycamore/tests/web/main.rs
+++ b/packages/sycamore/tests/web/main.rs
@@ -351,6 +351,24 @@ fn reactive_property() {
 }
 
 #[wasm_bindgen_test]
+fn static_property() {
+    create_scope_immediate(|cx| {
+        let node = view! { cx,
+            input(prop:checked=true)
+        };
+
+        sycamore::render_to(|_| node, &test_container());
+        let input: web_sys::HtmlInputElement = document()
+            .query_selector("input")
+            .unwrap()
+            .unwrap()
+            .unchecked_into();
+
+        assert!(input.checked());
+    });
+}
+
+#[wasm_bindgen_test]
 #[ignore]
 fn two_way_bind_to_props() {
     create_scope_immediate(|cx| {


### PR DESCRIPTION
Adds the ability to set properties directly in the view macro that
accepts any value that can be converted into the `JsValue`.

Supports both static and dynamic values in a similar manner that
attributes do currently.

Updates some of the examples to use the new directive when the type can
be used directly as a property instead of cloning or serializing the
value.

I did update the website to include a section on this new directive but there
is not a similar section for the builder API, so I'm not sure if you want to keep
this out or whether you'd like me to add something similar for the builder docs :).

Closes #330