### PR TITLE
Add debug implementations

### DIFF
--- a/packages/sycamore-core/src/component.rs
+++ b/packages/sycamore-core/src/component.rs
@@ -43,6 +43,11 @@ pub fn element_like_component_builder<'a, T: Prop + 'a, G: GenericNode>(
 pub struct Children<'a, G: GenericNode> {
     f: Box<dyn FnOnce(BoundedScope<'_, 'a>) -> View<G> + 'a>,
 }
+impl<'a, G: GenericNode> std::fmt::Debug for Children<'a, G> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Children").finish()
+    }
+}
 
 impl<'a, F, G: GenericNode> From<F> for Children<'a, G>
 where

--- a/packages/sycamore-core/src/lib.rs
+++ b/packages/sycamore-core/src/lib.rs
@@ -7,6 +7,8 @@
 //!
 //! - `hydrate` - Enables the hydration API.
 
+#![deny(missing_debug_implementations)]
+
 pub mod component;
 pub mod generic_node;
 #[cfg(feature = "hydrate")]

--- a/packages/sycamore-futures/src/lib.rs
+++ b/packages/sycamore-futures/src/lib.rs
@@ -1,5 +1,7 @@
 //! Futures support for reactive scopes.
 
+#![deny(missing_debug_implementations)]
+
 use std::pin::Pin;
 
 use futures::future::abortable;

--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -1,5 +1,7 @@
 //! Proc-macros used in [Sycamore](https://sycamore-rs.netlify.app).
 
+#![deny(missing_debug_implementations)]
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput};

--- a/packages/sycamore-reactive/src/lib.rs
+++ b/packages/sycamore-reactive/src/lib.rs
@@ -1,6 +1,7 @@
 //! Reactive primitives for Sycamore.
 
 #![warn(missing_docs)]
+#![deny(missing_debug_implementations)]
 
 mod arena;
 mod context;
@@ -85,6 +86,11 @@ pub struct BoundedScope<'a, 'b: 'a> {
     /// `&'b` for covariance!
     _phantom: PhantomData<&'b ()>,
 }
+impl<'a, 'b: 'a> std::fmt::Debug for BoundedScope<'a, 'b> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BoundedScope").finish()
+    }
+}
 
 impl<'a, 'b: 'a> BoundedScope<'a, 'b> {
     fn new(raw: &'a ScopeRaw<'a>) -> Self {
@@ -128,6 +134,11 @@ impl<'a> ScopeRaw<'a> {
 /// A handle that allows cleaning up a [`Scope`].
 pub struct ScopeDisposer<'a> {
     f: Box<dyn FnOnce() + 'a>,
+}
+impl<'a> std::fmt::Debug for ScopeDisposer<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScopeDisposer").finish()
+    }
 }
 
 impl<'a> ScopeDisposer<'a> {

--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -15,6 +15,11 @@ pub(crate) type SignalEmitterInner = RefCell<IndexMap<EffectCallbackPtr, WeakEff
 /// A struct for managing subscriptions to signals.
 #[derive(Default, Clone)]
 pub struct SignalEmitter(pub(crate) Rc<SignalEmitterInner>);
+impl std::fmt::Debug for SignalEmitter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SignalEmitter").finish()
+    }
+}
 
 #[derive(Default, Clone)]
 pub(crate) struct WeakSignalEmitter(pub Weak<SignalEmitterInner>);
@@ -254,6 +259,7 @@ impl<T> Signal<T> {
 /// A mutable reference for modifying a [`Signal`].
 ///
 /// Construct this using the [`Signal::modify()`] method.
+#[derive(Debug)]
 pub struct Modify<'a, T>(Option<T>, &'a Signal<T>);
 
 impl<'a, T> Deref for Modify<'a, T> {

--- a/packages/sycamore-router-macro/src/lib.rs
+++ b/packages/sycamore-router-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_debug_implementations)]
+
 mod parser;
 mod route;
 

--- a/packages/sycamore-router/src/lib.rs
+++ b/packages/sycamore-router/src/lib.rs
@@ -1,6 +1,7 @@
 //! The Sycamore Router.
 
 #![warn(missing_docs)]
+#![deny(missing_debug_implementations)]
 
 // Alias self to sycamore_router for proc-macros.
 extern crate self as sycamore_router;
@@ -34,7 +35,7 @@ pub trait Route: Sized {
 }
 
 /// Represents an URL segment or segments.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Segment {
     /// Match a specific segment.
     Param(String),
@@ -74,7 +75,7 @@ impl<'a> Capture<'a> {
 }
 
 /// A list of [`Segment`]s.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RoutePath {
     segments: Vec<Segment>,
 }

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -30,7 +30,7 @@ thread_local! {
 /// A router integration that uses the
 /// [HTML5 History API](https://developer.mozilla.org/en-US/docs/Web/API/History_API) to keep the
 /// UI in sync with the URL.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct HistoryIntegration {
     /// This field is to prevent downstream users from creating a new `HistoryIntegration` without
     /// the `new` method.
@@ -141,7 +141,7 @@ fn base_pathname() -> String {
 }
 
 /// Props for [`Router`].
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct RouterProps<'a, R, F, I, G>
 where
     R: Route + 'a,
@@ -229,7 +229,7 @@ where
 }
 
 /// Props for [`StaticRouter`].
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct StaticRouterProps<'a, R, F, G>
 where
     R: Route + 'a,

--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -8,6 +8,8 @@
 //! This crate is re-exported in the `sycamore` crate. It is recommended to use that instead of
 //! using this crate directly.
 
+#![deny(missing_debug_implementations)]
+
 mod dom_node;
 #[cfg(feature = "hydrate")]
 pub mod hydrate;

--- a/packages/sycamore/src/builder.rs
+++ b/packages/sycamore/src/builder.rs
@@ -37,6 +37,13 @@ pub struct ElementBuilder<'a, G: GenericNode, F: FnOnce(Scope<'a>) -> G + 'a>(
     F,
     PhantomData<&'a ()>,
 );
+impl<'a, G: GenericNode, F: FnOnce(Scope<'a>) -> G + 'a> std::fmt::Debug
+    for ElementBuilder<'a, G, F>
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ElementBuilder").finish()
+    }
+}
 
 /// A trait that is implemented only for [`ElementBuilder`] and [`View`].
 /// This should be considered implementation details and should not be used.

--- a/packages/sycamore/src/flow.rs
+++ b/packages/sycamore/src/flow.rs
@@ -8,7 +8,7 @@ use std::hash::Hash;
 use crate::prelude::*;
 
 /// Props for [`Keyed`].
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct KeyedProps<'a, T, F, G: GenericNode, K, Key>
 where
     F: Fn(BoundedScope<'_, 'a>, T) -> View<G> + 'a,
@@ -50,7 +50,7 @@ where
 }
 
 /// Props for [`Indexed`].
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct IndexedProps<'a, G: GenericNode, T, F>
 where
     F: Fn(BoundedScope<'_, 'a>, T) -> View<G> + 'a,

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -32,6 +32,7 @@
 #![warn(rust_2018_idioms)]
 #![deny(clippy::trait_duplication_in_bounds)]
 #![deny(clippy::type_repetition_in_bounds)]
+#![deny(missing_debug_implementations)]
 
 // Alias self to `sycamore` to make it possible to use proc-macros within the `sycamore` crate.
 #[allow(unused_extern_crates)] // False positive

--- a/packages/sycamore/src/motion.rs
+++ b/packages/sycamore/src/motion.rs
@@ -157,6 +157,11 @@ impl<T: Lerp + Clone, const N: usize> Lerp for [T; N] {
 
 /// A state that is interpolated when it is set.
 pub struct Tweened<'a, T: Lerp + Clone>(Rc<RefCell<TweenedInner<'a, T>>>);
+impl<'a, T: Lerp + Clone> std::fmt::Debug for Tweened<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Tweened").finish()
+    }
+}
 
 struct TweenedInner<'a, T: Lerp + Clone + 'a> {
     /// The [`Scope`] under which the tweened signal was created. We need to hold on to the

--- a/packages/sycamore/src/suspense.rs
+++ b/packages/sycamore/src/suspense.rs
@@ -17,7 +17,7 @@ struct SuspenseState {
 }
 
 /// Props for [`Suspense`].
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct SuspenseProps<'a, G: GenericNode> {
     /// The fallback [`View`] to display while the child nodes are being awaited.
     #[builder(default)]
@@ -129,7 +129,7 @@ pub async fn await_suspense<U>(cx: Scope<'_>, f: impl Future<Output = U>) -> U {
 
 /// A struct to handle transitions. Created using
 /// [`use_transition`].
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TransitionHandle<'a> {
     cx: Scope<'a>,
     is_pending: &'a Signal<bool>,

--- a/packages/sycamore/src/web/html.rs
+++ b/packages/sycamore/src/web/html.rs
@@ -26,6 +26,7 @@ macro_rules! define_elements {
             #[allow(non_camel_case_types)]
             #[doc = concat!("Build a [`<", stringify!($el), ">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/", stringify!($el), ") element.")]
             $(#[$attr])*
+            #[derive(Debug)]
             pub struct $el {}
 
             impl SycamoreElement for $el {

--- a/packages/sycamore/src/web/mod.rs
+++ b/packages/sycamore/src/web/mod.rs
@@ -62,7 +62,7 @@ pub async fn render_to_string_await_suspense(
 
 /// Props for [`NoHydrate`].
 #[cfg(feature = "hydrate")]
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct NoHydrateProps<'a, G: GenericNode> {
     children: Children<'a, G>,
 }
@@ -103,7 +103,7 @@ pub fn NoHydrate<'a, G: Html>(cx: Scope<'a>, props: NoHydrateProps<'a, G>) -> Vi
 
 /// Props for [`NoSsr`].
 #[cfg(feature = "hydrate")]
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct NoSsrProps<'a, G: GenericNode> {
     children: Children<'a, G>,
 }

--- a/packages/sycamore/src/web/portal.rs
+++ b/packages/sycamore/src/web/portal.rs
@@ -8,7 +8,7 @@ use crate::component::Children;
 use crate::prelude::*;
 
 /// Props for [`Portal`].
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct PortalProps<'a, G>
 where
     G: GenericNode,


### PR DESCRIPTION
This adds `Debug` implementations to all public items exported by all Sycamore crates, additionally adding the restriction that this trait must be implemented for all future exports.

Closes #412.