### PR TITLE
Add debug impl for RouterBaseProps

### DIFF
--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -173,7 +173,7 @@ where
 }
 
 /// Props for [`RouterBase`].
-#[derive(Prop)]
+#[derive(Prop, Debug)]
 pub struct RouterBaseProps<'a, R, F, I, G>
 where
     R: Route + 'a,


### PR DESCRIPTION
Missing debug after #441 added by #434.

I noticed this because the website failed to build.