### PR TITLE
Fix typo in docs/next/basics/iteration.md

### DIFF
--- a/docs/next/basics/iteration.md
+++ b/docs/next/basics/iteration.md
@@ -53,7 +53,7 @@ single node will be re-rendered every time the list changes.
 let count = vec![1, 2];
 
 let views = View::new_fragment(
-    count.iter().map(|&x| view! { cx, li (x) }).collect()
+    count.iter().map(|&x| view! { cx, li { (x) } }).collect()
 );
 
 view! { cx,


### PR DESCRIPTION
Added missing curly brackets to a list node inside a view! macro