### PR TITLE
Refactor web tests

### DIFF
--- a/packages/sycamore/tests/web/builder_hydrate.rs
+++ b/packages/sycamore/tests/web/builder_hydrate.rs
@@ -132,35 +132,14 @@ mod dynamic {
 
             sycamore::hydrate_to(|_| v(cx, state), &c);
 
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .text_content()
-                    .unwrap(),
-                "0"
-            );
+            assert_text_content!(query("p"), "0");
 
             // Reactivity should work normally.
             state.set(1);
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .text_content()
-                    .unwrap(),
-                "1"
-            );
+            assert_text_content!(query("p"), "1");
 
             // P tag should still be the SSR-ed node, not a new node.
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .get_attribute("data-hk")
-                    .as_deref(),
-                Some("0.0")
-            );
+            assert_eq!(query("p").get_attribute("data-hk").as_deref(), Some("0.0"));
         });
     }
 }
@@ -193,24 +172,10 @@ mod dynamic_with_siblings {
 
             // Reactivity should work normally.
             state.set(1);
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .text_content()
-                    .unwrap(),
-                "Value: 1!"
-            );
+            assert_text_content!(query("p"), "Value: 1!");
 
             // P tag should still be the SSR-ed node, not a new node.
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .get_attribute("data-hk")
-                    .as_deref(),
-                Some("0.0")
-            );
+            assert_eq!(query("p").get_attribute("data-hk").as_deref(), Some("0.0"));
         });
     }
 }
@@ -244,24 +209,10 @@ mod dynamic_template {
 
             // Reactivity should work normally.
             state.set(view! { cx, span { "nested node" } });
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .text_content()
-                    .unwrap(),
-                "beforenested nodeafter"
-            );
+            assert_text_content!(query("p"), "beforenested nodeafter");
 
             // P tag should still be the SSR-ed node, not a new node.
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .get_attribute("data-hk")
-                    .as_deref(),
-                Some("0.0")
-            );
+            assert_eq!(query("p").get_attribute("data-hk").as_deref(), Some("0.0"));
         });
     }
 }
@@ -291,7 +242,7 @@ mod top_level_dynamic_with_siblings {
 
             // Reactivity should work normally.
             state.set(1);
-            assert_eq!(c.text_content().unwrap(), "Value: 1!");
+            assert_text_content!(c, "Value: 1!");
         });
     }
 }

--- a/packages/sycamore/tests/web/hydrate.rs
+++ b/packages/sycamore/tests/web/hydrate.rs
@@ -131,35 +131,14 @@ mod dynamic {
 
             sycamore::hydrate_to(|_| v(cx, state), &c);
 
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .text_content()
-                    .unwrap(),
-                "0"
-            );
+            assert_text_content!(query("p"), "0");
 
             // Reactivity should work normally.
             state.set(1);
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .text_content()
-                    .unwrap(),
-                "1"
-            );
+            assert_text_content!(query("p"), "1");
 
             // P tag should still be the SSR-ed node, not a new node.
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .get_attribute("data-hk")
-                    .as_deref(),
-                Some("0.0")
-            );
+            assert_eq!(query("p").get_attribute("data-hk").as_deref(), Some("0.0"));
         });
     }
 }
@@ -189,24 +168,10 @@ mod dynamic_with_siblings {
 
             // Reactivity should work normally.
             state.set(1);
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .text_content()
-                    .unwrap(),
-                "Value: 1!"
-            );
+            assert_text_content!(query("p"), "Value: 1!");
 
             // P tag should still be the SSR-ed node, not a new node.
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .get_attribute("data-hk")
-                    .as_deref(),
-                Some("0.0")
-            );
+            assert_eq!(query("p").get_attribute("data-hk").as_deref(), Some("0.0"));
         });
     }
 }
@@ -236,24 +201,10 @@ mod dynamic_template {
 
             // Reactivity should work normally.
             state.set(view! { cx, span { "nested node" } });
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .text_content()
-                    .unwrap(),
-                "beforenested nodeafter"
-            );
+            assert_text_content!(query("p"), "beforenested nodeafter");
 
             // P tag should still be the SSR-ed node, not a new node.
-            assert_eq!(
-                c.query_selector("p")
-                    .unwrap()
-                    .unwrap()
-                    .get_attribute("data-hk")
-                    .as_deref(),
-                Some("0.0")
-            );
+            assert_eq!(query("p").get_attribute("data-hk").as_deref(), Some("0.0"));
         });
     }
 }
@@ -283,7 +234,7 @@ mod top_level_dynamic_with_siblings {
 
             // Reactivity should work normally.
             state.set(1);
-            assert_eq!(c.text_content().unwrap(), "Value: 1!");
+            assert_text_content!(c, "Value: 1!");
         });
     }
 }

--- a/packages/sycamore/tests/web/indexed.rs
+++ b/packages/sycamore/tests/web/indexed.rs
@@ -20,19 +20,19 @@ fn append() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
+        let p = query("ul");
 
-        assert_eq!(p.text_content().unwrap(), "12");
+        assert_text_content!(p, "12");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.push(3);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
 
         count.set(count.get()[1..].into());
-        assert_eq!(p.text_content().unwrap(), "23");
+        assert_text_content!(p, "23");
     });
 }
 
@@ -54,22 +54,22 @@ fn swap_rows() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.swap(0, 2);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "321");
+        assert_text_content!(p, "321");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.swap(0, 2);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
     });
 }
 
@@ -91,11 +91,11 @@ fn update_row() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "12");
+        let p = query("ul");
+        assert_text_content!(p, "12");
 
         count.set(vec![1, 3]);
-        assert_eq!(p.text_content().unwrap(), "13");
+        assert_text_content!(p, "13");
     });
 }
 
@@ -117,11 +117,11 @@ fn trigger_with_same_data() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "12");
+        let p = query("ul");
+        assert_text_content!(p, "12");
 
         count.set(count.get().as_ref().clone());
-        assert_eq!(p.text_content().unwrap(), "12");
+        assert_text_content!(p, "12");
     });
 }
 
@@ -143,15 +143,15 @@ fn delete_row() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.remove(1);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "13");
+        assert_text_content!(p, "13");
     });
 }
 
@@ -173,11 +173,11 @@ fn delete_row_from_start() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "12");
+        let p = query("ul");
+        assert_text_content!(p, "12");
 
         count.set(count.get().iter().cloned().skip(1).collect());
-        assert_eq!(p.text_content().unwrap(), "2");
+        assert_text_content!(p, "2");
     });
 }
 
@@ -199,11 +199,11 @@ fn delete_row_from_end() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "12");
+        let p = query("ul");
+        assert_text_content!(p, "12");
 
         count.set(count.get().iter().cloned().take(1).collect());
-        assert_eq!(p.text_content().unwrap(), "1");
+        assert_text_content!(p, "1");
     });
 }
 
@@ -225,11 +225,11 @@ fn clear() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.set(Vec::new());
-        assert_eq!(p.text_content().unwrap(), "");
+        assert_text_content!(p, "");
     });
 }
 
@@ -251,15 +251,15 @@ fn insert_front() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.insert(0, 4);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "4123");
+        assert_text_content!(p, "4123");
     });
 }
 
@@ -287,18 +287,18 @@ fn nested_reactivity() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.get()[0].set(4);
-        assert_eq!(p.text_content().unwrap(), "423");
+        assert_text_content!(p, "423");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.push(create_signal(cx, 5));
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "4235");
+        assert_text_content!(p, "4235");
     });
 }
 
@@ -321,10 +321,10 @@ fn fragment_template() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("div").unwrap().unwrap();
+        let div = query("div");
 
-        assert_eq!(
-            p.text_content().unwrap(),
+        assert_text_content!(
+            div,
             "\
     The value is: 1\
     The value is: 2"
@@ -335,8 +335,8 @@ fn fragment_template() {
             tmp.push(3);
             tmp
         });
-        assert_eq!(
-            p.text_content().unwrap(),
+        assert_text_content!(
+            div,
             "\
     The value is: 1\
     The value is: 2\
@@ -344,8 +344,8 @@ fn fragment_template() {
         );
 
         count.set(count.get()[1..].into());
-        assert_eq!(
-            p.text_content().unwrap(),
+        assert_text_content!(
+            div,
             "\
     The value is: 2\
     The value is: 3"
@@ -369,22 +369,19 @@ fn template_top_level() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document()
-            .query_selector("#test-container")
-            .unwrap()
-            .unwrap();
+        let p = query("#test-container");
 
-        assert_eq!(p.text_content().unwrap(), "12");
+        assert_text_content!(p, "12");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.push(3);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
 
         count.set(count.get()[1..].into());
-        assert_eq!(p.text_content().unwrap(), "23");
+        assert_text_content!(p, "23");
     });
 }
 
@@ -406,22 +403,19 @@ fn template_dyn_top_level() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document()
-            .query_selector("#test-container")
-            .unwrap()
-            .unwrap();
+        let p = query("#test-container");
 
-        assert_eq!(p.text_content().unwrap(), "12");
+        assert_text_content!(p, "12");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.push(3);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
 
         count.set(count.get()[1..].into());
-        assert_eq!(p.text_content().unwrap(), "23");
+        assert_text_content!(p, "23");
     });
 }
 
@@ -452,17 +446,17 @@ fn template_with_other_nodes_at_same_level() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let elem = document().query_selector("ul").unwrap().unwrap();
+        let elem = query("ul");
 
-        assert_eq!(elem.text_content().unwrap(), "before1245after");
+        assert_text_content!(elem, "before1245after");
 
         vec1.set(vec1.get().iter().cloned().chain(once(3)).collect());
-        assert_eq!(elem.text_content().unwrap(), "before12345after");
+        assert_text_content!(elem, "before12345after");
 
         vec1.set(Vec::new());
-        assert_eq!(elem.text_content().unwrap(), "before45after");
+        assert_text_content!(elem, "before45after");
 
         vec1.set(vec![1]);
-        assert_eq!(elem.text_content().unwrap(), "before145after");
+        assert_text_content!(elem, "before145after");
     });
 }

--- a/packages/sycamore/tests/web/keyed.rs
+++ b/packages/sycamore/tests/web/keyed.rs
@@ -21,19 +21,19 @@ fn append() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
+        let p = query("ul");
 
-        assert_eq!(p.text_content().unwrap(), "12");
+        assert_text_content!(p, "12");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.push(3);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
 
         count.set(count.get()[1..].into());
-        assert_eq!(p.text_content().unwrap(), "23");
+        assert_text_content!(p, "23");
     });
 }
 
@@ -56,22 +56,22 @@ fn swap_rows() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.swap(0, 2);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "321");
+        assert_text_content!(p, "321");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.swap(0, 2);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
     });
 }
 
@@ -94,11 +94,11 @@ fn update_row() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "12");
+        let p = query("ul");
+        assert_text_content!(p, "12");
 
         count.set(vec![1, 3]);
-        assert_eq!(p.text_content().unwrap(), "13");
+        assert_text_content!(p, "13");
     });
 }
 
@@ -121,11 +121,11 @@ fn trigger_with_same_data() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "12");
+        let p = query("ul");
+        assert_text_content!(p, "12");
 
         count.set(count.get().as_ref().clone());
-        assert_eq!(p.text_content().unwrap(), "12");
+        assert_text_content!(p, "12");
     });
 }
 
@@ -148,15 +148,15 @@ fn delete_row() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.remove(1);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "13");
+        assert_text_content!(p, "13");
     });
 }
 
@@ -179,11 +179,11 @@ fn delete_row_from_start() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "12");
+        let p = query("ul");
+        assert_text_content!(p, "12");
 
         count.set(count.get().iter().cloned().skip(1).collect());
-        assert_eq!(p.text_content().unwrap(), "2");
+        assert_text_content!(p, "2");
     });
 }
 
@@ -206,11 +206,11 @@ fn delete_row_from_end() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "12");
+        let p = query("ul");
+        assert_text_content!(p, "12");
 
         count.set(count.get().iter().cloned().take(1).collect());
-        assert_eq!(p.text_content().unwrap(), "1");
+        assert_text_content!(p, "1");
     });
 }
 
@@ -233,11 +233,11 @@ fn clear() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.set(Vec::new());
-        assert_eq!(p.text_content().unwrap(), "");
+        assert_text_content!(p, "");
     });
 }
 
@@ -260,15 +260,15 @@ fn insert_front() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.insert(0, 4);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "4123");
+        assert_text_content!(p, "4123");
     });
 }
 
@@ -297,18 +297,18 @@ fn nested_reactivity() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("ul").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "123");
+        let p = query("ul");
+        assert_text_content!(p, "123");
 
         count.get()[0].set(4);
-        assert_eq!(p.text_content().unwrap(), "423");
+        assert_text_content!(p, "423");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.push(create_signal(cx, 5));
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "4235");
+        assert_text_content!(p, "4235");
     });
 }
 
@@ -332,10 +332,10 @@ fn fragment_template() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document().query_selector("div").unwrap().unwrap();
+        let p = query("div");
 
-        assert_eq!(
-            p.text_content().unwrap(),
+        assert_text_content!(
+            p,
             "\
     The value is: 1\
     The value is: 2"
@@ -346,8 +346,8 @@ fn fragment_template() {
             tmp.push(3);
             tmp
         });
-        assert_eq!(
-            p.text_content().unwrap(),
+        assert_text_content!(
+            p,
             "\
     The value is: 1\
     The value is: 2\
@@ -355,8 +355,8 @@ fn fragment_template() {
         );
 
         count.set(count.get()[1..].into());
-        assert_eq!(
-            p.text_content().unwrap(),
+        assert_text_content!(
+            p,
             "\
     The value is: 2\
     The value is: 3"
@@ -381,22 +381,19 @@ fn template_top_level() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document()
-            .query_selector("#test-container")
-            .unwrap()
-            .unwrap();
+        let p = query("#test-container");
 
-        assert_eq!(p.text_content().unwrap(), "12");
+        assert_text_content!(p, "12");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.push(3);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
 
         count.set(count.get()[1..].into());
-        assert_eq!(p.text_content().unwrap(), "23");
+        assert_text_content!(p, "23");
     });
 }
 
@@ -419,22 +416,19 @@ fn template_dyn_top_level() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let p = document()
-            .query_selector("#test-container")
-            .unwrap()
-            .unwrap();
+        let p = query("#test-container");
 
-        assert_eq!(p.text_content().unwrap(), "12");
+        assert_text_content!(p, "12");
 
         count.set({
             let mut tmp = (*count.get()).clone();
             tmp.push(3);
             tmp
         });
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
 
         count.set(count.get()[1..].into());
-        assert_eq!(p.text_content().unwrap(), "23");
+        assert_text_content!(p, "23");
     });
 }
 
@@ -467,17 +461,17 @@ fn template_with_other_nodes_at_same_level() {
 
         sycamore::render_to(|_| node, &test_container());
 
-        let elem = document().query_selector("ul").unwrap().unwrap();
+        let elem = query("ul");
 
-        assert_eq!(elem.text_content().unwrap(), "before1245after");
+        assert_text_content!(elem, "before1245after");
 
         vec1.set(vec1.get().iter().cloned().chain(once(3)).collect());
-        assert_eq!(elem.text_content().unwrap(), "before12345after");
+        assert_text_content!(elem, "before12345after");
 
         vec1.set(Vec::new());
-        assert_eq!(elem.text_content().unwrap(), "before45after");
+        assert_text_content!(elem, "before45after");
 
         vec1.set(vec![1]);
-        assert_eq!(elem.text_content().unwrap(), "before145after");
+        assert_text_content!(elem, "before145after");
     });
 }

--- a/packages/sycamore/tests/web/main.rs
+++ b/packages/sycamore/tests/web/main.rs
@@ -10,21 +10,16 @@ pub mod reconcile;
 pub mod render;
 pub mod svg;
 
+mod utils;
+
 use sycamore::prelude::*;
 use sycamore::web::html;
+use utils::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
-use web_sys::{Document, Element, Event, HtmlElement, HtmlInputElement, Node, Window};
+use web_sys::{Element, Event, HtmlElement, HtmlInputElement};
 
 wasm_bindgen_test_configure!(run_in_browser);
-
-fn window() -> Window {
-    web_sys::window().unwrap()
-}
-
-fn document() -> Document {
-    window().document().unwrap()
-}
 
 /// Returns a [`Element`] referencing the test container with the contents cleared.
 fn test_container() -> Element {
@@ -43,10 +38,7 @@ fn test_container() -> Element {
             .unwrap();
     }
 
-    let container = document()
-        .query_selector("test-container#test-container")
-        .unwrap()
-        .unwrap();
+    let container = query("test-container#test-container");
 
     container.set_inner_html(""); // erase contents from previous test runs
 
@@ -56,14 +48,7 @@ fn test_container() -> Element {
 #[wasm_bindgen_test]
 fn empty_template() {
     sycamore::render_to(|_| View::empty(), &test_container());
-    assert_eq!(
-        document()
-            .query_selector("#test-container")
-            .unwrap()
-            .unwrap()
-            .inner_html(),
-        "<!---->"
-    );
+    assert_eq!(query("#test-container").inner_html(), "<!---->");
 }
 
 #[wasm_bindgen_test]
@@ -76,14 +61,7 @@ fn hello_world() {
         },
         &test_container(),
     );
-    assert_eq!(
-        &document()
-            .query_selector("p")
-            .unwrap()
-            .unwrap()
-            .outer_html(),
-        "<p>Hello World!</p>"
-    );
+    assert_eq!(query("p").outer_html(), "<p>Hello World!</p>");
 }
 
 #[wasm_bindgen_test]
@@ -120,15 +98,7 @@ fn interpolation() {
         &test_container(),
     );
 
-    assert_eq!(
-        document()
-            .query_selector("p")
-            .unwrap()
-            .unwrap()
-            .text_content()
-            .unwrap(),
-        "Hello Sycamore!"
-    );
+    assert_text_content!(query("p"), "Hello Sycamore!");
 }
 
 #[wasm_bindgen_test]
@@ -144,15 +114,7 @@ fn template_interpolation() {
         },
         &test_container(),
     );
-    assert_eq!(
-        document()
-            .query_selector("p")
-            .unwrap()
-            .unwrap()
-            .text_content()
-            .unwrap(),
-        "Hello Sycamore!"
-    );
+    assert_text_content!(query("p"), "Hello Sycamore!");
 }
 
 #[wasm_bindgen_test]
@@ -169,37 +131,13 @@ fn template_interpolation_if_else() {
             }
         };
         sycamore::render_to(|_| node, &test_container());
-        assert_eq!(
-            document()
-                .query_selector("p")
-                .unwrap()
-                .unwrap()
-                .text_content()
-                .unwrap(),
-            "Hello Sycamore!"
-        );
+        assert_text_content!(query("p"), "Hello Sycamore!");
 
         show.set(false);
-        assert_eq!(
-            document()
-                .query_selector("p")
-                .unwrap()
-                .unwrap()
-                .text_content()
-                .unwrap(),
-            ""
-        );
+        assert_text_content!(query("p"), "");
 
         show.set(true);
-        assert_eq!(
-            document()
-                .query_selector("p")
-                .unwrap()
-                .unwrap()
-                .text_content()
-                .unwrap(),
-            "Hello Sycamore!"
-        );
+        assert_text_content!(query("p"), "Hello Sycamore!");
     });
 }
 
@@ -216,37 +154,13 @@ fn template_interpolation_if_else_with_sibling() {
             })
         };
         sycamore::render_to(|_| node, &test_container());
-        assert_eq!(
-            document()
-                .query_selector("p")
-                .unwrap()
-                .unwrap()
-                .text_content()
-                .unwrap(),
-            "Hello Sycamore!"
-        );
+        assert_text_content!(query("p"), "Hello Sycamore!");
 
         show.set(false);
-        assert_eq!(
-            document()
-                .query_selector("p")
-                .unwrap()
-                .unwrap()
-                .text_content()
-                .unwrap(),
-            ""
-        );
+        assert_text_content!(query("p"), "");
 
         show.set(true);
-        assert_eq!(
-            document()
-                .query_selector("p")
-                .unwrap()
-                .unwrap()
-                .text_content()
-                .unwrap(),
-            "Hello Sycamore!"
-        );
+        assert_text_content!(query("p"), "Hello Sycamore!");
     });
 }
 
@@ -262,11 +176,11 @@ fn template_interpolation_nested_reactivity() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let p = document().query_selector("p").unwrap().unwrap();
-        assert_eq!(p.text_content().unwrap(), "0");
+        let p = query("p");
+        assert_text_content!(p, "0");
 
         count.set(1);
-        assert_eq!(p.text_content().unwrap(), "1");
+        assert_text_content!(p, "1");
     });
 }
 
@@ -280,12 +194,12 @@ fn reactive_text() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let p = document().query_selector("p").unwrap().unwrap();
+        let p = query("p");
 
-        assert_eq!(p.text_content().unwrap(), "0");
+        assert_text_content!(p, "0");
 
         count.set(1);
-        assert_eq!(p.text_content().unwrap(), "1");
+        assert_text_content!(p, "1");
     });
 }
 
@@ -299,12 +213,12 @@ fn reactive_text_do_not_destroy_previous_children() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let p = document().query_selector("p").unwrap().unwrap();
+        let p = query("p");
 
-        assert_eq!(p.text_content().unwrap(), "Value: 0");
+        assert_text_content!(p, "Value: 0");
 
         count.set(1);
-        assert_eq!(p.text_content().unwrap(), "Value: 1");
+        assert_text_content!(p, "Value: 1");
     });
 }
 
@@ -318,7 +232,7 @@ fn reactive_attribute() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let span = document().query_selector("span").unwrap().unwrap();
+        let span = query("span");
 
         assert_eq!(span.get_attribute("attribute").unwrap(), "0");
 
@@ -337,11 +251,7 @@ fn reactive_property() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let input: web_sys::HtmlInputElement = document()
-            .query_selector("input")
-            .unwrap()
-            .unwrap()
-            .unchecked_into();
+        let input: HtmlInputElement = query_into("input");
 
         assert!(input.indeterminate());
 
@@ -358,11 +268,7 @@ fn static_property() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let input: web_sys::HtmlInputElement = document()
-            .query_selector("input")
-            .unwrap()
-            .unwrap()
-            .unchecked_into();
+        let input: HtmlInputElement = query_into("input");
 
         assert!(input.checked());
     });
@@ -380,19 +286,12 @@ fn two_way_bind_to_props() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let input = document()
-            .query_selector("input")
-            .unwrap()
-            .unwrap()
-            .unchecked_into::<HtmlInputElement>();
+        let input: HtmlInputElement = query_into("input");
 
         value.set("abc".to_string());
-        assert_eq!(
-            js_sys::Reflect::get(&input, &"value".into()).unwrap(),
-            "abc"
-        );
+        assert_eq!(input.value(), "abc");
 
-        js_sys::Reflect::set(&input, &"value".into(), &"def".into()).unwrap();
+        input.set_value("def");
         input.dispatch_event(&Event::new("input").unwrap()).unwrap();
         assert_eq!(value.get().as_str(), "def");
     });
@@ -409,12 +308,9 @@ fn noderefs() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let input_ref = document().query_selector("input").unwrap().unwrap();
+        let input_ref = query("input");
 
-        assert_eq!(
-            Node::from(input_ref),
-            noderef.get::<DomNode>().unchecked_into()
-        );
+        assert_eq!(input_ref, noderef.get::<DomNode>().unchecked_into());
     });
 }
 
@@ -427,12 +323,8 @@ fn fragments() {
             p { "3" }
         };
         sycamore::render_to(|_| node, &test_container());
-        let test_container = document()
-            .query_selector("#test-container")
-            .unwrap()
-            .unwrap();
 
-        assert_eq!(test_container.text_content().unwrap(), "123");
+        assert_text_content!(query("#test-container"), "123");
     });
 }
 
@@ -446,12 +338,8 @@ fn fragments_text_nodes() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let test_container = document()
-            .query_selector("#test-container")
-            .unwrap()
-            .unwrap();
 
-        assert_eq!(test_container.text_content().unwrap(), "123");
+        assert_text_content!(query("#test-container"), "123");
     });
 }
 
@@ -468,12 +356,9 @@ fn dyn_fragment_reuse_nodes() {
             &test_container(),
         );
 
-        let p = document()
-            .query_selector("#test-container")
-            .unwrap()
-            .unwrap();
+        let p = query("#test-container");
 
-        assert_eq!(p.text_content().unwrap(), "123");
+        assert_text_content!(p, "123");
         assert!(p.first_child() == nodes[0].as_node().map(|node| node.inner_element()));
     });
 }

--- a/packages/sycamore/tests/web/reconcile.rs
+++ b/packages/sycamore/tests/web/reconcile.rs
@@ -26,7 +26,7 @@ fn insert_create_nodes() {
             None,
             true,
         );
-        assert_eq!(parent.inner_element().text_content().unwrap(), "123");
+        assert_text_content!(parent.inner_element(), "123");
     });
 }
 
@@ -43,10 +43,10 @@ fn reconcile_pop_nodes() {
     for node in &child_nodes {
         parent.append_child(node);
     }
-    assert_eq!(parent.inner_element().text_content().unwrap(), "123");
+    assert_text_content!(parent.inner_element(), "123");
 
     reconcile_fragments(&parent, &mut child_nodes.clone(), &nodes[..2]);
-    assert_eq!(parent.inner_element().text_content().unwrap(), "12");
+    assert_text_content!(parent.inner_element(), "12");
 }
 
 #[wasm_bindgen_test]
@@ -62,14 +62,14 @@ fn reconcile_remove_nodes() {
     for node in &child_nodes {
         parent.append_child(node);
     }
-    assert_eq!(parent.inner_element().text_content().unwrap(), "123");
+    assert_text_content!(parent.inner_element(), "123");
 
     reconcile_fragments(
         &parent,
         &mut child_nodes.clone(),
         &[nodes[0].clone(), nodes[2].clone()],
     );
-    assert_eq!(parent.inner_element().text_content().unwrap(), "13");
+    assert_text_content!(parent.inner_element(), "13");
 }
 
 #[wasm_bindgen_test]
@@ -85,10 +85,10 @@ fn reconcile_append_nodes() {
     for node in &child_nodes {
         parent.append_child(node);
     }
-    assert_eq!(parent.inner_element().text_content().unwrap(), "12");
+    assert_text_content!(parent.inner_element(), "12");
 
     reconcile_fragments(&parent, &mut child_nodes.clone(), &nodes);
-    assert_eq!(parent.inner_element().text_content().unwrap(), "123");
+    assert_text_content!(parent.inner_element(), "123");
 }
 
 #[wasm_bindgen_test]
@@ -104,14 +104,14 @@ fn reconcile_swap_nodes() {
     for node in &child_nodes {
         parent.append_child(node);
     }
-    assert_eq!(parent.inner_element().text_content().unwrap(), "123");
+    assert_text_content!(parent.inner_element(), "123");
 
     reconcile_fragments(
         &parent,
         &mut child_nodes.clone(),
         &[nodes[2].clone(), nodes[1].clone(), nodes[0].clone()],
     );
-    assert_eq!(parent.inner_element().text_content().unwrap(), "321");
+    assert_text_content!(parent.inner_element(), "321");
 }
 
 #[wasm_bindgen_test]
@@ -127,10 +127,10 @@ fn reconcile_clear_nodes() {
     for node in &child_nodes {
         parent.append_child(node);
     }
-    assert_eq!(parent.inner_element().text_content().unwrap(), "123");
+    assert_text_content!(parent.inner_element(), "123");
 
     reconcile_fragments(&parent, &mut child_nodes.clone(), &[]);
-    assert_eq!(parent.inner_element().text_content().unwrap(), "");
+    assert_text_content!(parent.inner_element(), "");
 }
 
 #[wasm_bindgen_test]
@@ -150,22 +150,13 @@ fn clear_and_insert_with_other_nodes_at_same_level() {
     }
     parent.append_child(&after);
 
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "before123after"
-    );
+    assert_text_content!(parent.inner_element(), "before123after");
 
     reconcile_fragments(&parent, &mut child_nodes.clone(), &[]);
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "beforeafter"
-    );
+    assert_text_content!(parent.inner_element(), "beforeafter");
 
     append_nodes(&parent, child_nodes, Some(&after));
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "before123after"
-    );
+    assert_text_content!(parent.inner_element(), "before123after");
 }
 
 #[wasm_bindgen_test]
@@ -185,16 +176,10 @@ fn clear_with_other_nodes_at_same_level() {
     }
     parent.append_child(&after);
 
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "before123after"
-    );
+    assert_text_content!(parent.inner_element(), "before123after");
 
     reconcile_fragments(&parent, &mut child_nodes.clone(), &[]);
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "beforeafter"
-    );
+    assert_text_content!(parent.inner_element(), "beforeafter");
 }
 
 #[wasm_bindgen_test]
@@ -214,16 +199,10 @@ fn insert_with_other_nodes_at_same_level() {
     }
     parent.append_child(&after);
 
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "before123after"
-    );
+    assert_text_content!(parent.inner_element(), "before123after");
 
     reconcile_fragments(&parent, &mut child_nodes.clone(), &child_nodes[..2]);
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "before12after"
-    );
+    assert_text_content!(parent.inner_element(), "before12after");
 }
 
 #[wasm_bindgen_test]
@@ -243,14 +222,8 @@ fn reconcile_with_other_nodes_at_same_level() {
     }
     parent.append_child(&after);
 
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "before123after"
-    );
+    assert_text_content!(parent.inner_element(), "before123after");
 
     reconcile_fragments(&parent, &mut child_nodes.clone(), &child_nodes[..2]);
-    assert_eq!(
-        parent.inner_element().text_content().unwrap(),
-        "before12after"
-    );
+    assert_text_content!(parent.inner_element(), "before12after");
 }

--- a/packages/sycamore/tests/web/render.rs
+++ b/packages/sycamore/tests/web/render.rs
@@ -12,15 +12,7 @@ fn lazy() {
         });
 
         sycamore::render_to(|_| node, &test_container());
-        assert_eq!(
-            document()
-                .query_selector("div")
-                .unwrap()
-                .unwrap()
-                .text_content()
-                .unwrap(),
-            "Test"
-        );
+        assert_text_content!(query("div"), "Test");
     });
 }
 
@@ -36,17 +28,14 @@ fn lazy_reactive() {
         let node: View<DomNode> = View::new_dyn(cx, || (*template.get()).clone());
 
         sycamore::render_to(|_| node, &test_container());
-        let test_container = document()
-            .query_selector("test-container")
-            .unwrap()
-            .unwrap();
+        let test_container = query("test-container");
 
-        assert_eq!(test_container.text_content().unwrap(), "1");
+        assert_text_content!(test_container, "1");
 
         template.set(view! { cx,
             "2"
         });
-        assert_eq!(test_container.text_content().unwrap(), "2");
+        assert_text_content!(test_container, "2");
     });
 }
 
@@ -62,15 +51,12 @@ fn lazy_in_fragment() {
         };
 
         sycamore::render_to(|_| node, &test_container());
-        let test_container = document()
-            .query_selector("test-container")
-            .unwrap()
-            .unwrap();
+        let test_container = query("test-container");
 
-        assert_eq!(test_container.text_content().unwrap(), "before0after");
+        assert_text_content!(test_container, "before0after");
 
         num.set(1);
 
-        assert_eq!(test_container.text_content().unwrap(), "before1after");
+        assert_text_content!(test_container, "before1after");
     });
 }

--- a/packages/sycamore/tests/web/svg.rs
+++ b/packages/sycamore/tests/web/svg.rs
@@ -10,4 +10,8 @@ fn issue_391_svg_with_class_should_not_use_classname() {
         },
         &test_container(),
     );
+
+    let svg = query("svg");
+
+    assert_eq!(svg.get_attribute("class").unwrap(), "my-class");
 }

--- a/packages/sycamore/tests/web/utils.rs
+++ b/packages/sycamore/tests/web/utils.rs
@@ -1,0 +1,33 @@
+use wasm_bindgen::JsCast;
+use web_sys::{Document, Element, HtmlElement, Window};
+
+pub(crate) fn window() -> Window {
+    web_sys::window().unwrap()
+}
+
+pub(crate) fn document() -> Document {
+    window().document().unwrap()
+}
+
+pub(crate) fn query(selectors: &str) -> Element {
+    document()
+        .query_selector(selectors)
+        .expect("selectors should be valid")
+        .expect("element to be found that matches the selectors")
+}
+
+pub(crate) fn query_into<T: AsRef<HtmlElement> + JsCast>(selectors: &str) -> T {
+    // dyn_into -> unwrap to eagerly cause a panic if the query doesn't match
+    // the generic T.
+    query(selectors)
+        .dyn_into()
+        .expect("element found should be of the same type as used for the generic T")
+}
+
+macro_rules! assert_text_content {
+    ($element: expr, $right: expr $(,)?) => {
+        assert_eq!($element.text_content().unwrap(), $right);
+    };
+}
+
+pub(crate) use assert_text_content;

--- a/packages/sycamore/tests/web/utils.rs
+++ b/packages/sycamore/tests/web/utils.rs
@@ -9,6 +9,14 @@ pub(crate) fn document() -> Document {
     window().document().unwrap()
 }
 
+/// Query the `Document` for the first `Element` that matches the selectors.
+///
+/// This is a test utility function only!
+///
+/// # Panics
+///
+/// Panics if the selectors string is invalid or if no element was found that
+/// matches the selectors
 pub(crate) fn query(selectors: &str) -> Element {
     document()
         .query_selector(selectors)
@@ -16,6 +24,17 @@ pub(crate) fn query(selectors: &str) -> Element {
         .expect("element to be found that matches the selectors")
 }
 
+/// Query the `Document` for the first `Element` that matches the selectors and
+/// then try to cast it into the generic type `T`.
+///
+/// This is a test utility function only!
+///
+/// # Panics
+///
+/// Panics if:
+/// - the selectors string is invalid
+/// - no element was found that matches the selectors
+/// - element found cannot be cast to the generic type `T` used
 pub(crate) fn query_into<T: AsRef<HtmlElement> + JsCast>(selectors: &str) -> T {
     // dyn_into -> unwrap to eagerly cause a panic if the query doesn't match
     // the generic T.
@@ -24,6 +43,8 @@ pub(crate) fn query_into<T: AsRef<HtmlElement> + JsCast>(selectors: &str) -> T {
         .expect("element found should be of the same type as used for the generic T")
 }
 
+/// Asserts that the text content of a `web_sys::Node` is equal to the
+/// right expression.
 macro_rules! assert_text_content {
     ($element: expr, $right: expr $(,)?) => {
         assert_eq!($element.text_content().unwrap(), $right);


### PR DESCRIPTION
Hi 👋,

This PR does five things for the tests in `packages/sycamore/tests/web/`. 

1. Add `query` utility function to replace `{document}.query_selector({selectors}).unwrap().unwrap()`
2. Add `query_into` utility function to replace `{document}.query_selector({selectors}).unwrap().unwrap().unchecked_into::<{element_type}>()`
3. Add a new `assert_text_content` macro, which is similar to `assert_eq` but it will call `Node::text_content` and `unwrap` the value for the `left` expression before passing it to `assert_eq`.
4. Uses the methods available in `HtmlInputElement` for getting and setting the `value` property instead of using the `Reflect` methods.
5. I noticed the svg test which didn't assert that the class was added correctly, so I thought I'd add the assertion for this :)

Hopefully you agree this makes writing and reading these types of tests easier :)