### PR TITLE
Allow fragments and dynamic views in `RouterBase`

### DIFF
--- a/packages/sycamore-core/src/generic_node.rs
+++ b/packages/sycamore-core/src/generic_node.rs
@@ -128,6 +128,8 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
     fn remove_self(&self);
 
     /// Add a event handler to the event `name`.
+    /// The event should be removed once the scope is disposed, as to prevent accessing scope
+    /// variables after the scope is disposed.
     fn event<'a, F: FnMut(Self::EventType) + 'a>(&self, cx: Scope<'a>, name: &str, handler: F);
 
     /// Update inner text of the node. If the node has elements, all the elements are replaced with

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -276,13 +276,17 @@ where
         }
     }));
     let route_signal = create_memo(cx, move || route.match_path(&pathname.get()));
-    // Delegate click events from child <a> tags.
     let view = view(cx, route_signal);
+    // Delegate click events from child <a> tags.
     if let Some(node) = view.as_node() {
         node.event(cx, "click", integration.click_handler());
     } else {
-        // TODO: support fragments and dynamic nodes
-        unimplemented!("support fragments and dynamic nodes for Router")
+        let view = view.clone();
+        create_effect_scoped(cx, move |cx| {
+            for node in view.clone().flatten() {
+                node.event(cx, "click", integration.click_handler());
+            }
+        });
     }
     view
 }


### PR DESCRIPTION
Previously, `Router` would panic if the children was node a single node. This meant that fragments and dynamic views had to be wrapped by another node (often a `<div>` or a `<main>`). This PR removes this restriction.