### PR TITLE
Forward compatibility fix for breakage due to a soundness fix in rustc

### DIFF
--- a/packages/sycamore/src/builder.rs
+++ b/packages/sycamore/src/builder.rs
@@ -84,7 +84,7 @@ impl<'a, G: GenericNode, F: FnOnce(Scope<'a>) -> G + 'a> ElementBuilderOrView<'a
 /// // etc...
 /// ```
 pub fn tag<'a, G: GenericNode>(
-    t: impl AsRef<str>,
+    t: impl AsRef<str> + 'a,
 ) -> ElementBuilder<'a, G, impl FnOnce(Scope<'a>) -> G> {
     ElementBuilder::new(move |_| G::element_from_tag(t.as_ref()))
 }
@@ -423,7 +423,7 @@ impl<'a, G: GenericNode, F: FnOnce(Scope<'a>) -> G + 'a> ElementBuilder<'a, G, F
     /// ```
     pub fn c(
         self,
-        c: impl ElementBuilderOrView<'a, G>,
+        c: impl ElementBuilderOrView<'a, G> + 'a,
     ) -> ElementBuilder<'a, G, impl FnOnce(Scope<'a>) -> G + 'a> {
         self.map(|cx, el| render::insert(cx, el, c.into_view(cx), None, None, true))
     }


### PR DESCRIPTION
In https://github.com/rust-lang/rust/pull/95474#issuecomment-1228705007 we are attempting to deploy a soundness bug fix for rare cases of `impl Trait` causing UB. While your crate does not use this unsoundly, it requires an additional annotation in order for rustc to be able to figure out that your case is actually sound.

This change was done by following the [diagnostics emitted by the rustc that contains the bugfix](https://crater-reports.s3.amazonaws.com/pr-95474-1/try%23d47ae2a6ecee02f32f23667fe1152f9a71e39e8c/reg/perseus-0.4.0-beta.7/log.txt).