### PR TITLE
Avoid possible shadowing of existing bindings in macro expansion

### DIFF
--- a/packages/sycamore-macro/src/view/codegen.rs
+++ b/packages/sycamore-macro/src/view/codegen.rs
@@ -27,14 +27,14 @@ impl Codegen {
                     .iter()
                     .map(|node| {
                         let quoted = self.view_node(node);
-                        quote! { children.push(#quoted); }
+                        quote! { #quoted, }
                     })
                     .collect();
                 quote! {
                     ::sycamore::view::View::new_fragment({
-                        let mut children = ::std::vec::Vec::new();
-                        #append_nodes
-                        children
+                        ::std::vec![
+                            #append_nodes
+                        ]
                     })
                 }
             }

--- a/packages/sycamore-macro/tests/view/component-pass.rs
+++ b/packages/sycamore-macro/tests/view/component-pass.rs
@@ -23,6 +23,18 @@ pub fn ComponentWithChildren<'a, G: Html>(cx: Scope<'a>, prop: PropWithChildren<
 }
 
 #[component]
+pub fn NestedComponentWithChildren<'a, G: Html>(cx: Scope<'a>, prop: PropWithChildren<'a, G>) -> View<G> {
+    let children = prop.children.call(cx);
+
+    view! { cx,
+        ComponentWithChildren {
+            (children)
+            Component {}
+        }
+    }
+}
+
+#[component]
 pub async fn AsyncComponentWithPropDestructuring<'a, G: Html>(
     cx: Scope<'a>,
     PropWithChildren { children }: PropWithChildren<'a, G>,
@@ -58,6 +70,12 @@ fn compile_pass<G: Html>() {
 
         let _: View<G> = view! { cx,
             AsyncComponentWithPropDestructuring {
+                Component {}
+            }
+        };
+
+        let _: View<G> = view! { cx,
+            NestedComponentWithChildren {
                 Component {}
             }
         };


### PR DESCRIPTION
Solves #476 by collecting children in a single expression without binding to a variable.