### PR TITLE
adding `change` and `change_silent`

### DIFF
--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -228,6 +228,25 @@ impl<T> Signal<T> {
         self.trigger_subscribers();
     }
 
+    /// Set the value of the state using a function that receives the current value.
+    ///
+    /// This will notify and update any effects and memos that depend on this value.
+    ///
+    /// # Example
+    /// ```
+    /// # use sycamore_reactive::*;
+    /// # create_scope_immediate(|cx| {
+    /// let state = create_signal(cx, 0);
+    /// assert_eq!(*state.get(), 0);
+    ///
+    /// state.change(|n| n + 1);
+    /// assert_eq!(*state.get(), 1);
+    /// # });
+    /// ```
+    pub fn change<F: Fn(&T) -> T>(&self, change_fn: F) {
+        self.set(change_fn(&self.get_untracked()));
+    }
+
     /// Set the current value of the state wrapped in a [`Rc`]. Unlike [`Signal::set()`], this
     /// method accepts the value wrapped in a [`Rc`] because the underlying storage is already using
     /// [`Rc`], thus preventing an unnecessary clone.
@@ -256,6 +275,13 @@ impl<T> Signal<T> {
     /// Make sure you know what you are doing because this can make state inconsistent.
     pub fn set_silent(&self, value: T) {
         self.set_rc_silent(Rc::new(value));
+    }
+
+    /// Set the value of the state using a function that receives the current value _without_ triggering subscribers.
+    ///
+    /// Make sure you know what you are doing because this can make state inconsistent.
+    pub fn change_silent<F: Fn(&T) -> T>(&self, change_fn: F) {
+        self.set_silent(change_fn(&self.get_untracked()));
     }
 
     /// Set the current value of the state wrapped in a [`Rc`] _without_ triggering subscribers.
@@ -636,6 +662,9 @@ mod tests {
 
             state.set(1);
             assert_eq!(*state.get(), 1);
+
+            state.change(|n| n + 1);
+            assert_eq!(*state.get(), 2);
         });
     }
 
@@ -659,6 +688,9 @@ mod tests {
 
             assert_eq!(*double.get(), 0);
             state.set_silent(1);
+            assert_eq!(*double.get(), 0); // double value is unchanged.
+
+            state.change_silent(|n| n + 1);
             assert_eq!(*double.get(), 0); // double value is unchanged.
         });
     }


### PR DESCRIPTION
Hey there! :)

I thought a convenience function like `change` would be nice in order to avoid needing a `state.get()` call for simple use cases. This is done in `solidjs` as well: https://www.solidjs.com/tutorial/introduction_signals

Let me know if there are any changes you'd like made :)

P.S., I chose `Fn(&T) -> T` to avoid requiring `Copy` or `Clone` on T. This is only really intended for the simplest situations.