### PR TITLE
Remove redundant set_value in todomvc example

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -254,13 +254,7 @@ pub fn Item<G: Html>(cx: Scope, todo: RcSignal<Todo>) -> View<G> {
         let event: KeyboardEvent = event.unchecked_into();
         match event.key().as_str() {
             "Enter" => handle_blur(),
-            "Escape" => {
-                input_ref
-                    .get::<DomNode>()
-                    .unchecked_into::<HtmlInputElement>()
-                    .set_value(&title());
-                is_editing.set(false);
-            }
+            "Escape" => is_editing.set(false),
             _ => {}
         }
     };


### PR DESCRIPTION
It seems that setting the value of the input field does not affect the behavior of the program in any way