### PR TITLE
Remove data-hk attribute after hydration

### DIFF
--- a/packages/sycamore-web/src/hydrate.rs
+++ b/packages/sycamore-web/src/hydrate.rs
@@ -20,6 +20,10 @@ pub fn get_next_element() -> Option<Element> {
             .unwrap()
             .query_selector(&format!("[data-hk=\"{}.{}\"]", hk.0, hk.1))
             .unwrap()
+            .map(|e| {
+                e.remove_attribute("data-hk");
+                e
+            })
     } else {
         None
     }

--- a/packages/sycamore-web/src/hydrate.rs
+++ b/packages/sycamore-web/src/hydrate.rs
@@ -21,7 +21,7 @@ pub fn get_next_element() -> Option<Element> {
             .query_selector(&format!("[data-hk=\"{}.{}\"]", hk.0, hk.1))
             .unwrap()
             .map(|e| {
-                e.remove_attribute("data-hk");
+                e.remove_attribute("data-hk").unwrap();
                 e
             })
     } else {


### PR DESCRIPTION
Currently, hydrating multiple components on the same page in sycamore does not work. This is because, across mount boundaries, elements can have the same `data-hk` value and thus confuses sycamore.

This can be fixed by simply removing `data-hk` immediately after each element is hydrated. We can only do in-order from-top-to-bottom multi-component hydration, but that's more than sufficient.

This PR allows sycamore to [support island architecture](https://github.com/corepaper/east/tree/master/examples/counter). rel https://github.com/sycamore-rs/sycamore/issues/200