### PR TITLE
Add `Result` and `Option` APIs to `Signal` for more ergonomic usage

### DIFF
--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -222,7 +222,7 @@ impl<T, E> ReadSignal<Result<Rc<T>, Rc<E>>> {
     /// # });
     /// ```
     #[must_use = "to only subscribe the signal without using the value, use .track() instead"]
-    pub fn get_opt(&self) -> Result<Rc<T>, Rc<E>> {
+    pub fn get_res(&self) -> Result<Rc<T>, Rc<E>> {
         self.get()
             .as_ref()
             .as_ref()
@@ -416,7 +416,7 @@ impl<T, E> Signal<Result<Rc<T>, Rc<E>>> {
     /// assert_eq!(state.get_opt(), Some(Rc::new(1)));
     /// # });
     /// ```
-    pub fn set_opt(&self, value: Result<T, E>) {
+    pub fn set_res(&self, value: Result<T, E>) {
         self.set(value.map(Rc::new).map_err(Rc::new))
     }
 }

--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -822,6 +822,17 @@ mod tests {
     }
 
     #[test]
+    fn result_signal() {
+        create_scope_immediate(|cx| {
+            let state = create_res_signal(cx, Ok(0));
+            assert_eq!(state.get_res(), Ok(Rc::new(0)));
+
+            state.set_res(Err(1));
+            assert_eq!(state.get_res(), Err(Rc::new(1)));
+        });
+    }
+
+    #[test]
     fn signal_composition() {
         create_scope_immediate(|cx| {
             let state = create_signal(cx, 0);
@@ -857,6 +868,30 @@ mod tests {
             assert_eq!(*readonly.get(), 0);
             state.set(1);
             assert_eq!(*readonly.get(), 1);
+        });
+    }
+
+    #[test]
+    fn read_opt_signal() {
+        create_scope_immediate(|cx| {
+            let state = create_opt_signal(cx, Some(0));
+            let readonly: &ReadSignal<Option<Rc<i32>>> = state.deref();
+
+            assert_eq!(readonly.get_opt(), Some(Rc::new(0)));
+            state.set_opt(Some(1));
+            assert_eq!(readonly.get_opt(), Some(Rc::new(1)));
+        });
+    }
+
+    #[test]
+    fn read_res_signal() {
+        create_scope_immediate(|cx| {
+            let state = create_res_signal(cx, Ok(0));
+            let readonly: &ReadSignal<Result<Rc<i32>, Rc<i32>>> = state.deref();
+
+            assert_eq!(readonly.get_res(), Ok(Rc::new(0)));
+            state.set_res(Err(1));
+            assert_eq!(readonly.get_res(), Err(Rc::new(1)));
         });
     }
 


### PR DESCRIPTION
This PR adds APIs to ergonomically create and use `Signal<Option<Rc<T>>>` and `Signal<Result<Rc<T>, Rc<E>>>`.

The getter unwraps the outer `Rc` to return the `Option<Rc<T>>` instead of `Rc<Option<Rc<T>>>`, which is much easier to match on and generally work with. The setter and create functions take an `Option<T>` and wrap the value in an `Rc` because values rarely already come as an `Rc`. This is the same philosophy of why `set` exists in addition to `set_rc`, just applied to `Option` and `Result`.

I'm unsure about the naming and exact API and naming and would be happy to discuss changes. It currently only implements the most basic functionality (create, get, set) - should things like `modify` and `set_fn` also have special `Result` and `Option` variants?