### PR TITLE
adding `set_fn_mut` and `set_fn_mut_silent`

### DIFF
--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -247,6 +247,26 @@ impl<T> Signal<T> {
         self.set(f(&self.get_untracked()));
     }
 
+    /// Set the value of the state using a function that can mutate the value.
+    ///
+    /// This will notify and update any effects and memos that depend on this value.
+    ///
+    /// # Example
+    /// ```
+    /// # use sycamore_reactive::*;
+    /// # create_scope_immediate(|cx| {
+    /// let state = create_signal(cx, vec![]);
+    /// assert_eq!(*state.get(), vec![]);
+    ///
+    /// state.set_fn_mut(|&mut v| v.push(1));
+    /// assert_eq!(*state.get(), vec![1]);
+    /// # });
+    /// ```
+    pub fn set_fn_mut<F: FnMut(&mut T)>(&self, f: &mut F) {
+        f(&mut self.0.value.borrow_mut());
+        self.trigger_subscribers();
+    }
+
     /// Set the current value of the state wrapped in a [`Rc`]. Unlike [`Signal::set()`], this
     /// method accepts the value wrapped in a [`Rc`] because the underlying storage is already using
     /// [`Rc`], thus preventing an unnecessary clone.
@@ -666,6 +686,9 @@ mod tests {
 
             state.set_fn(|n| n + 1);
             assert_eq!(*state.get(), 2);
+
+            state.set_fn_mut(&mut |n: &mut _| *n = 5);
+            assert_eq!(*state.get(), 5);
         });
     }
 

--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -722,6 +722,13 @@ mod tests {
             assert_eq!(double(), 0);
             state.set(1);
             assert_eq!(double(), 2);
+
+            let state = create_signal(cx, vec![1]);
+            let sum = state.map(cx, |v| v.iter().sum::<isize>());
+            assert_eq!(*sum.get(), 1);
+            state.set_fn_mut(|v| v.push(1));
+            assert_eq!(*state.get(), vec![1, 1]);
+            assert_eq!(*sum.get(), 2);
         });
     }
 


### PR DESCRIPTION
More convenience functions :) These `set_fn_mut` variants use [`RefCell::borrow_mut`](https://doc.rust-lang.org/std/cell/struct.RefCell.html#method.borrow_mut) and [`Rc::get_mut`](https://doc.rust-lang.org/std/rc/struct.Rc.html#method.get_mut) to directly mutably borrow the underlying value without a clone. 

I thought you would consider the possible panics acceptable since the `Modify` implementation does the same thing. It seems this is safe to do, since the borrow only lasts during the function's synchronous call and won't conflict with other borrows since `Rc` can't be sent across thread boundaries.

Am I crazy? There are tests covering it even with dependent signals, so it seems safe!