### PR TITLE
Add unique ID generation hook

### DIFF
--- a/packages/sycamore-core/src/lib.rs
+++ b/packages/sycamore-core/src/lib.rs
@@ -16,4 +16,5 @@ pub mod generic_node;
 pub mod hydrate;
 pub mod noderef;
 pub mod render;
+pub mod stable_id;
 pub mod view;

--- a/packages/sycamore-core/src/stable_id.rs
+++ b/packages/sycamore-core/src/stable_id.rs
@@ -1,0 +1,76 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Create a unique ID that's stable between SSR and hydration.
+///
+/// Returns the current component ID and the local hook index in hydration contexts,
+/// or a global hook index outside of a hydration context.
+/// Use this to generate stable IDs for things like accessiblity attributes.
+///
+/// # Example
+///
+/// ```
+/// # use sycamore::prelude::create_unique_id;
+/// let (component_id, id) = create_unique_id();
+/// ```
+pub fn create_unique_id() -> (Option<usize>, usize) {
+    static LAST_COMPONENT_ID: AtomicUsize = AtomicUsize::new(0);
+    static CURRENT_HOOK_ID: AtomicUsize = AtomicUsize::new(0);
+
+    #[cfg(feature = "hydrate")]
+    if let Some((component_id, _)) = crate::hydrate::get_current_id() {
+        return if component_id == LAST_COMPONENT_ID.swap(component_id, Ordering::Relaxed) {
+            (
+                Some(component_id),
+                CURRENT_HOOK_ID.fetch_add(1, Ordering::Relaxed),
+            )
+        } else {
+            CURRENT_HOOK_ID.store(1, Ordering::Relaxed);
+            (Some(component_id), 0)
+        };
+    }
+
+    // Unhydrated IDs don't have a component ID
+    static CURRENT_ID: AtomicUsize = AtomicUsize::new(0);
+    let id = CURRENT_ID.fetch_add(1, Ordering::Relaxed);
+    (None, id)
+}
+
+#[cfg(test)]
+mod test {
+    use super::create_unique_id;
+
+    #[test]
+    pub fn ids_increment() {
+        let (_, id1) = create_unique_id();
+        let (_, id2) = create_unique_id();
+        let (_, id3) = create_unique_id();
+
+        assert_eq!(id1, 0);
+        assert_eq!(id2, 1);
+        assert_eq!(id3, 2);
+    }
+
+    #[cfg(feature = "hydrate")]
+    #[test]
+    pub fn id_is_stable() {
+        use crate::hydrate::{hydrate_component, with_hydration_context};
+
+        let (id1, id2, id3) = with_hydration_context(|| {
+            let id1 = create_unique_id();
+            let (id2, id3) = hydrate_component(|| (create_unique_id(), create_unique_id()));
+            (id1, id2, id3)
+        });
+
+        assert_eq!(id1, (Some(0), 0));
+        assert_eq!(id2, (Some(1), 0));
+        assert_eq!(id3, (Some(1), 1));
+
+        with_hydration_context(|| {
+            assert_eq!(id1, create_unique_id());
+            hydrate_component(|| {
+                assert_eq!(id2, create_unique_id());
+                assert_eq!(id3, create_unique_id());
+            });
+        });
+    }
+}

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -51,7 +51,7 @@ pub mod utils;
 pub mod web;
 
 /* Re-export modules from sycamore-core */
-pub use sycamore_core::{component, generic_node, noderef, view};
+pub use sycamore_core::{component, generic_node, noderef, stable_id, view};
 /* Re-export of the sycamore-macro crate */
 pub use sycamore_macro::*;
 
@@ -87,6 +87,7 @@ pub mod prelude {
     pub use crate::generic_node::GenericNode;
     pub use crate::noderef::{create_node_ref, NodeRef};
     pub use crate::reactive::*;
+    pub use crate::stable_id::create_unique_id;
     pub use crate::view::View;
     #[cfg(feature = "web")]
     pub use crate::web::macros::{node, view};


### PR DESCRIPTION
This adds a way to generate IDs that are stable across the hydration boundary. If a hydration context is not available, it will fall back to a globally incremented ID.
This is useful for generating ids for accessible components and similar uses that require a stable globally unique ID.

# Example use case

```rust
let (component_id, id) = create_unique_id();
view! { cx,
    div(aria-labelledby = format!("{}_{id}", component_id.unwrap_or_default())) {
        // children
    }
}
```

The format boilerplate would likely be abstracted into a custom hook specific to the application, this just provides the primitive so the IDs are guaranteed to be globally unique.