### PR TITLE
Fix Issue #572

### DIFF
--- a/packages/sycamore-core/src/render.rs
+++ b/packages/sycamore-core/src/render.rs
@@ -67,10 +67,7 @@ fn insert_expression<G: GenericNode>(
             let marker = marker.cloned();
             let f = f.clone();
             create_effect_scoped(cx, move |cx| {
-                let mut value = f.get();
-                while let ViewType::Dyn(f) = &value.inner {
-                    value = f.get();
-                }
+                let value = f.get();
                 insert_expression(
                     cx,
                     &parent,

--- a/packages/sycamore/tests/web/render.rs
+++ b/packages/sycamore/tests/web/render.rs
@@ -82,18 +82,22 @@ fn dyn_nested() {
 #[wasm_bindgen_test]
 fn dyn_scoped_nested() {
     create_scope_immediate(|cx| {
+        let num = create_signal(cx, 0);
+
         let node: View<DomNode> = View::new_dyn_scoped(cx, move |cx| {
             View::new_dyn_scoped(cx, move |cx| {
                 view! { cx,
                     div {
-                        "Test"
+                        (num.get())
                     }
                 }
             })
         });
 
         sycamore::render_to(|_| node, &test_container());
-        assert_text_content!(query("div"), "Test");
+        assert_text_content!(query("div"), "0");
+        num.set(1);
+        assert_text_content!(query("div"), "1");
     });
 }
 

--- a/packages/sycamore/tests/web/render.rs
+++ b/packages/sycamore/tests/web/render.rs
@@ -96,3 +96,25 @@ fn dyn_scoped_nested() {
         assert_text_content!(query("div"), "Test");
     });
 }
+
+#[wasm_bindgen_test]
+fn regression_572() {
+    let signal = create_rc_signal(0);
+
+    sycamore::render_to(
+        {
+            let signal = signal.clone();
+            |cx| {
+                View::new_dyn_scoped(cx, move |cx| {
+                    let signal = signal.clone();
+                    View::new_dyn(cx, move || {
+                        signal.track();
+                        View::empty()
+                    })
+                })
+            }
+        },
+        &test_container(),
+    );
+    signal.set(0);
+}


### PR DESCRIPTION
This fixes the panic described in #572.

It removes the loop that unwraps inner dynamic views from the render code for `ViewType::Dyn`. I don't understand its purpose in the first place, no tests failed after removing it, TodoMVC still works exactly as expected and even my contrived example to specifically trigger that loop renders and updates perfectly fine. So I can only assume it was extraneous code left over from a refactor.