### PR TITLE
Add batch function to avoid extra effect executions

### DIFF
--- a/docs/next/advanced/advanced_reactivity.md
+++ b/docs/next/advanced/advanced_reactivity.md
@@ -9,3 +9,40 @@
 TODO
 
 Help us out by writing the docs and sending us a PR!
+
+## Batching Updates
+
+Sycamore's fine grained reactivity system updates immediately when a signal changes. This works great
+in most cases because only things that depend on that change will actually be rerun. But what if
+you need to make changes to two or more related signals?
+
+### The `batch` function
+
+The batch function lets you execute a closure and delay any updates until it completes. This means
+you can update multiple related signals and only have their dependents run once.
+
+Not only can this improve performance, but can even improve safety in your code since updating
+related signals synchronously can cause your effects to run with an unintended state. Batching
+the calls means you only ever run your effects when you're done with your mutations. You can think
+of batching a little bit like database transactions.
+
+### Example
+
+In this example, we are assigning both names on a button click and this triggers our rendered update
+twice. Using batch lets us avoid that.
+
+```rust
+let update_names = || {
+    batch(|| {
+        first_name.set_fn(|first_name| first_name + "n");
+        last_name.set_fn(|last_name| last_name + "!");
+    });
+}
+
+let full_name = create_memo(cx, || {
+    // This would run twice when `update_names` is called without batching. With batching, it only
+    // runs once.
+    format!("{} {}", first_name.get(), last_name.get());
+});
+```
+

--- a/packages/sycamore-reactive/src/signal.rs
+++ b/packages/sycamore-reactive/src/signal.rs
@@ -932,4 +932,27 @@ mod tests {
             let _rc_signal: RcSignal<i32> = create_rc_signal_from_rc(Rc::new(0));
         });
     }
+
+    #[test]
+    fn batch_signal_updates() {
+        create_scope_immediate(|cx| {
+            let signal1 = create_signal(cx, "Hello");
+            let signal2 = create_signal(cx, "World");
+            let counter = create_signal(cx, 0);
+
+            create_effect(cx, || {
+                signal1.track();
+                signal2.track();
+                counter.set_fn(|i| i + 1);
+            });
+
+            batch(|| {
+                signal1.set("Hellooo");
+                signal2.set("Sycamore");
+            });
+            assert_eq!(*signal1.get(), "Hellooo");
+            assert_eq!(*signal2.get(), "Sycamore");
+            assert_eq!(*counter.get(), 2);
+        });
+    }
 }


### PR DESCRIPTION
This adds a `batch` function inspired by SolidJS. It holds and deduplicates signal emitters called during its closure so effects using multiple signals are only run once.
This is not just important for performance, but can affect functionality. For example, moving an item from one list to another - without batching any effects depending on the lists would run once in an incorrect state where the item is missing completely or exists twice.

I'm not 100% on the implementation, but it works. I just dislike the (small) impact it has on non-batched signal updates. Not sure how you would do it without some sort of check in the `Signal` unfortunately.


