### PR TITLE
Update Trunk, NodeJS, and MSRV to 1.65

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 18.x
 
       - name: Install trunk
         run: >

--- a/.github/workflows/build_website_prod.yml
+++ b/.github/workflows/build_website_prod.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 18.x
 
       - name: Install trunk
         run: >
           wget -qO-
-          https://github.com/thedodd/trunk/releases/download/v0.14.0/trunk-x86_64-unknown-linux-gnu.tar.gz
+          https://github.com/thedodd/trunk/releases/download/v0.16.0/trunk-x86_64-unknown-linux-gnu.tar.gz
           | tar -xzf- && sudo mv trunk /usr/bin/
 
       - name: Cargo generate-lockfile

--- a/.github/workflows/js_framework_bench.yml
+++ b/.github/workflows/js_framework_bench.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Install trunk
         run: >
           wget -qO-
-          https://github.com/thedodd/trunk/releases/download/v0.14.0/trunk-x86_64-unknown-linux-gnu.tar.gz
+          https://github.com/thedodd/trunk/releases/download/v0.16.0/trunk-x86_64-unknown-linux-gnu.tar.gz
           | tar -xzf- && sudo mv trunk /usr/bin/
 
       - name: Setup NodeJS
         uses: actions/setup-node@v1
         with:
-          node-version: 16.x
+          node-version: 18.x
 
       - name: Install chromedriver
         uses: nanasess/setup-chromedriver@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.63.0
+          - 1.65.0
           - stable
           - nightly
         os:

--- a/docs/next/getting_started/installation.md
+++ b/docs/next/getting_started/installation.md
@@ -17,7 +17,7 @@ rustup target add wasm32-unknown-unknown
 
 ### Minimum Supported Rust Version (MSRV) and Rust edition
 
-The minimum supported Rust toolchain is `v1.63.0`. Sycamore is not guaranteed to (and probably
+The minimum supported Rust toolchain is `v1.65.0`. Sycamore is not guaranteed to (and probably
 won't) compile on older versions of Rust.
 
 Sycamore only works on Rust edition 2021. Even though most crates written in edition 2021 are

--- a/website/sitemap_index.xml
+++ b/website/sitemap_index.xml
@@ -9,6 +9,7 @@
 <url><loc>https://sycamore-rs.netlify.app/news/announcing-v0.8.0</loc><changefreq>yearly</changefreq><priority>0.8</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/news/new-reactive-primitives</loc><changefreq>yearly</changefreq><priority>0.8</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/docs/advanced/advanced_reactivity</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
+<url><loc>https://sycamore-rs.netlify.app/docs/advanced/attributes_prop</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/docs/advanced/contexts</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/docs/advanced/js_interop</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/docs/advanced/noderef</loc><changefreq>weekly</changefreq><priority>0.5</priority></url>
@@ -121,6 +122,7 @@
 <url><loc>https://sycamore-rs.netlify.app/docs/v0.5/sidebar</loc><changefreq>yearly</changefreq><priority>0.3</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/hydrate</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/hello-builder</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://sycamore-rs.netlify.app/examples/attributes-passthrough</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/http-request</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/svg</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/counter</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
@@ -129,6 +131,7 @@
 <url><loc>https://sycamore-rs.netlify.app/examples/http-request-builder</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/timer</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/js-framework-benchmark</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
+<url><loc>https://sycamore-rs.netlify.app/examples/js-snippets</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/components</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/number-binding</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>
 <url><loc>https://sycamore-rs.netlify.app/examples/hello-world</loc><changefreq>monthly</changefreq><priority>0.5</priority></url>


### PR DESCRIPTION
Update Trunk to 0.16 in CI.
Update NodeJS to 18.x in CI.
Update MSRV to 1.65 (because `time-core` updated their MSRV).