### PR TITLE
fix view! parser to handle dashed attributes with Rust keywords (#620)

### DIFF
--- a/packages/sycamore-macro/src/view/parse.rs
+++ b/packages/sycamore-macro/src/view/parse.rs
@@ -204,7 +204,7 @@ impl Parse for AttributeName {
         let tag = input.call(Ident::parse_any)?;
         let mut extended = Vec::new();
         while input.peek(Token![-]) {
-            extended.push((input.parse()?, input.parse()?));
+            extended.push((input.parse()?, input.call(Ident::parse_any)?));
         }
 
         Ok(Self { tag, extended })

--- a/packages/sycamore-macro/tests/view/element-pass.rs
+++ b/packages/sycamore-macro/tests/view/element-pass.rs
@@ -21,6 +21,9 @@ fn compile_pass<G: Html>() {
 
         // view! should correctly parenthesize the (1 + 2) when borrowing.
         let _: View<G> = view! { cx, p { (1 + 2) } };
+
+        // view! should accept the pattern "-ref-" in an attribute name.
+        let _: View<G> = view! { cx, p(class="my-class", data-ref-me="my-value") };
     });
 }
 


### PR DESCRIPTION
Switches `view!` AttributeName parser to `Ident::parse_any` to handle keywords in extended attribute names.

fixes #620 

# Example
```rs
view! { cx, p(class="my-class", data-ref-me="my-value") }
```

Prior to change, this would throw with
```
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
error: expected identifier, found keyword `ref`
  --> tests/view/element-pass.rs:26:63
   |
26 |         let _: View<G> = view! { cx, p(class="my-class", data-ref-me="my-value") };
   |                                                               ^^^
┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈
```