### PR TITLE
Repace the `Memo` struct with `ReadSignal`

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -340,7 +340,7 @@ pub fn List<G: Html>() -> View<G> {
 
             ul(class="todo-list") {
                 Keyed(
-                    iterable=*filtered_todos,
+                    iterable=filtered_todos,
                     view=|todo| view! {
                         Item(todo=todo)
                     },

--- a/packages/sycamore-core/src/view.rs
+++ b/packages/sycamore-core/src/view.rs
@@ -52,7 +52,7 @@ impl<G: GenericNode> View<G> {
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn new_dyn(f: impl FnMut() -> View<G> + 'static) -> Self {
         Self {
-            inner: ViewType::Dyn(*create_memo(f).inner_signal()),
+            inner: ViewType::Dyn(create_memo(f)),
         }
     }
 

--- a/packages/sycamore-reactive/src/iter.rs
+++ b/packages/sycamore-reactive/src/iter.rs
@@ -23,7 +23,7 @@ pub fn map_keyed<T, K, U: 'static>(
     list: impl Accessor<Vec<T>> + Clone + 'static,
     map_fn: impl Fn(T) -> U + 'static,
     key_fn: impl Fn(&T) -> K + 'static,
-) -> Memo<Vec<U>>
+) -> ReadSignal<Vec<U>>
 where
     T: PartialEq + Clone + 'static,
     K: Eq + Hash,
@@ -187,7 +187,7 @@ where
 pub fn map_indexed<T, U: 'static>(
     list: impl Accessor<Vec<T>> + Clone + 'static,
     map_fn: impl Fn(T) -> U + 'static,
-) -> Memo<Vec<U>>
+) -> ReadSignal<Vec<U>>
 where
     T: PartialEq + Clone + 'static,
     U: Clone,

--- a/packages/sycamore-reactive/src/signals.rs
+++ b/packages/sycamore-reactive/src/signals.rs
@@ -10,7 +10,7 @@ use std::ops::{AddAssign, Deref, DivAssign, MulAssign, RemAssign, SubAssign};
 use slotmap::Key;
 use smallvec::SmallVec;
 
-use crate::{create_memo, Mark, Memo, NodeHandle, NodeId, NodeState, ReactiveNode, Root};
+use crate::{create_memo, Mark, NodeHandle, NodeId, NodeState, ReactiveNode, Root};
 
 /// A read-only reactive value.
 ///
@@ -368,7 +368,7 @@ impl<T> Signal<T> {
     }
 
     #[cfg_attr(debug_assertions, track_caller)]
-    pub fn map<U>(self, mut f: impl FnMut(&T) -> U + 'static) -> Memo<U> {
+    pub fn map<U>(self, mut f: impl FnMut(&T) -> U + 'static) -> ReadSignal<U> {
         create_memo(move || self.with(&mut f))
     }
 

--- a/packages/sycamore-reactive/src/utils.rs
+++ b/packages/sycamore-reactive/src/utils.rs
@@ -25,12 +25,6 @@ impl<T: Clone> Accessor<T> for ReadSignal<T> {
     }
 }
 
-impl<T: Clone> Accessor<T> for Memo<T> {
-    fn value(&self) -> T {
-        self.get_clone()
-    }
-}
-
 impl<T: Clone> Accessor<T> for T {
     fn value(&self) -> T {
         self.clone()
@@ -67,12 +61,6 @@ impl<T> Trackable for Signal<T> {
 }
 
 impl<T> Trackable for ReadSignal<T> {
-    fn _track(&self) {
-        self.track();
-    }
-}
-
-impl<T> Trackable for Memo<T> {
     fn _track(&self) {
         self.track();
     }

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -268,7 +268,7 @@ where
         }
     }));
     let route_signal = create_memo(move || pathname.with(|pathname| route.match_path(pathname)));
-    let view = view(*route_signal);
+    let view = view(route_signal);
     // Delegate click events from child <a> tags.
     if let Some(node) = view.as_node() {
         node.event(ev::click, integration.click_handler());

--- a/packages/tools/bench/benches/reactivity.rs
+++ b/packages/tools/bench/benches/reactivity.rs
@@ -109,7 +109,7 @@ pub fn bench(c: &mut Criterion) {
         b.iter(|| {
             let d = create_root(|| {
                 let signal = create_signal(0);
-                let mut memos = Vec::<Memo<usize>>::new();
+                let mut memos = Vec::<ReadSignal<usize>>::new();
                 for _ in 0..1000usize {
                     if let Some(prev) = memos.last().copied() {
                         memos.push(create_memo(move || prev.get() + 1));


### PR DESCRIPTION
`Memo` used to be a wrapper struct around `ReadSignal` which did not provide anything extra so this makes everything simpler.

Follow-up to #626 