### PR TITLE
Fix panic about current not being a child of parent in clean_children

### DIFF
--- a/packages/sycamore-core/src/render.rs
+++ b/packages/sycamore-core/src/render.rs
@@ -156,15 +156,21 @@ pub fn clean_children<G: GenericNode>(
         if let Some(replacement) = replacement {
             parent.append_child(replacement);
         }
-        return;
-    }
-
-    for node in current {
-        if node.parent_node().as_ref() == Some(parent) {
-            if let Some(replacement) = replacement {
-                parent.replace_child(&node, replacement);
+    } else {
+        debug_assert!(!current.is_empty());
+        for node in current {
+            if node.parent_node().as_ref() == Some(parent) {
+                if let Some(replacement) = replacement {
+                    parent.replace_child(&node, replacement);
+                } else {
+                    parent.remove_child(&node);
+                }
             } else {
-                parent.remove_child(&node);
+                // debug_assert_eq!(node.parent_node().as_ref(), Some(parent), "{node:?}");
+                // FIXME
+                if let Some(replacement) = replacement {
+                    parent.append_child(replacement);
+                }
             }
         }
     }


### PR DESCRIPTION
This is a bit of a hack right now. The right way to do it would be to ensure that `current` only includes nodes that are children of `parent` as a pre-condition of the function.

This temporarily fixes website navigation in debug mode.