### PR TITLE
Re-export `wasm-bindgen`, `js-sys`, and event types from `web-sys`

### DIFF
--- a/examples/js-framework-benchmark/Cargo.toml
+++ b/examples/js-framework-benchmark/Cargo.toml
@@ -10,5 +10,4 @@ console_error_panic_hook = "0.1.7"
 getrandom = { version = "0.2.8", features = ["js"] }
 rand = "0.8.5"
 sycamore = { path = "../../packages/sycamore" }
-wasm-bindgen = "0.2.83"
 web-sys = "0.3.60"

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -13,8 +13,7 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 sycamore = { path = "../../packages/sycamore", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4", "js"] }
-wasm-bindgen = "0.2.83"
 
 [dependencies.web-sys]
-features = ["InputEvent", "KeyboardEvent", "Location", "Storage"]
+features = ["Location", "Storage"]
 version = "0.3.60"

--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -31,9 +31,20 @@ pub use ssr_node::*;
 use sycamore_core::generic_node::{GenericNode, GenericNodeElements};
 use sycamore_reactive::*;
 use wasm_bindgen::prelude::*;
-pub use web_sys;
-pub use js_sys;
-pub use wasm_bindgen;
+/// Re-export of `js-sys` and `wasm-bindgen` for convenience.
+#[doc(no_inline)]
+pub use {js_sys, wasm_bindgen};
+
+/// Re-export of HTML event types from `web-sys` for convenience.
+pub mod events {
+    pub use web_sys::{
+        AnimationEvent, BeforeUnloadEvent, CompositionEvent, DeviceMotionEvent,
+        DeviceOrientationEvent, DragEvent, ErrorEvent, Event, FocusEvent, GamepadEvent,
+        HashChangeEvent, KeyboardEvent, MessageEvent, MouseEvent, PageTransitionEvent,
+        PointerEvent, PopStateEvent, ProgressEvent, StorageEvent, TouchEvent, TransitionEvent,
+        UiEvent, WheelEvent,
+    };
+}
 
 /// Trait that is implemented by all [`GenericNode`] backends that render to HTML.
 pub trait Html:


### PR DESCRIPTION
Supersedes #568 

This adds a re-export in `sycamore-web` of `wasm-bindgen`, `js-sys`, and _only_ the event types from `web-sys` which are used from within Sycamore.

The reason why we don't re-export the entirety of `web-sys` is because all of the APIs are behind feature flags so it is very likely that the downstream user of Sycamore will need to add `web-sys` as a dependency anyways.