### PR TITLE
Add missing docs and more doctests

### DIFF
--- a/packages/sycamore-core/src/component.rs
+++ b/packages/sycamore-core/src/component.rs
@@ -266,7 +266,7 @@ impl<G: GenericNode> Default for Attributes<G> {
 }
 
 impl<G: GenericNode> Attributes<G> {
-    // Creates a new [`Attributes`] struct from a map of keys and values.
+    /// Creates a new [`Attributes`] struct from a map of keys and values.
     pub fn new(attributes: HashMap<Cow<'static, str>, AttributeValue<G>>) -> Self {
         Self {
             attrs: RefCell::new(attributes),

--- a/packages/sycamore-core/src/event.rs
+++ b/packages/sycamore-core/src/event.rs
@@ -8,6 +8,7 @@ pub trait EventHandler<T, Ev, S>
 where
     Ev: EventDescriptor<T>,
 {
+    /// Call the event handler.
     fn call(&mut self, event: Ev::EventData);
 }
 

--- a/packages/sycamore-core/src/generic_node.rs
+++ b/packages/sycamore-core/src/generic_node.rs
@@ -136,6 +136,8 @@ pub trait GenericNode: fmt::Debug + Clone + PartialEq + Eq + Hash + 'static {
         self.untyped_event(Cow::Borrowed(Ev::EVENT_NAME), boxed)
     }
 
+    /// Add an untyped event handler for the event. This API is string-ly typed and can potentially
+    /// panic.
     fn untyped_event(
         &self,
         event: Cow<'_, str>,
@@ -231,13 +233,20 @@ pub fn __apply_dyn_values_to_template<G: GenericNodeElements>(
 /// filled in later.
 #[derive(Debug)]
 pub enum TemplateShape {
+    /// An element with children and attributes.
     Element {
+        /// The element tag.
         tag: &'static str,
+        /// The element namespace (e.g. HTML or SVG).
         ns: Option<&'static str>,
+        /// Element children.
         children: &'static [TemplateShape],
+        /// A list of attributes to set on the element.
         attributes: &'static [(&'static str, Cow<'static, str>)],
+        /// Flag this element so that we can refer to it later.
         flag: bool,
     },
+    /// A text node.
     Text(&'static str),
     /// A dynamic view "hole". This is where a dynamic view should be inserted.
     DynMarker,
@@ -250,31 +259,45 @@ pub struct TemplateId(pub u32);
 /// A template that can be instantiated.
 #[derive(Debug)]
 pub struct Template {
+    /// Unique ID of the template.
     pub id: TemplateId,
+    /// Shape of the template. Can be thought of as a view "schema".
     pub shape: TemplateShape,
 }
 
 /// Result of a template instantiation.
 #[derive(Debug)]
 pub struct TemplateResult<G: GenericNode> {
+    /// Reference to root node.
     pub root: G,
+    /// List of all flagged nodes that we can refer to.
     pub flagged_nodes: Vec<G>,
+    /// A list of dynamic markers.
     pub dyn_markers: Vec<DynMarkerResult<G>>,
 }
 
 /// Info extracted from a dynamic marker in a template.
 #[derive(Debug)]
 pub struct DynMarkerResult<G: GenericNode> {
+    /// Parent of the marker.
     pub parent: G,
+    /// Element before the marker.
     pub before: Option<G>,
+    /// Initial value of the marker.
     pub initial: Option<View<G>>,
+    /// Whether the marker is the only child or not.
     pub multi: bool,
 }
 
+/// Options for [`instantiate_template_universal`].
 pub struct InstantiateUniversalOpts<G: GenericNodeElements> {
+    /// Start of the marker.
     pub start_marker: Option<&'static str>,
+    /// End of the marker.
     pub end_marker: Option<&'static str>,
+    /// Function to create an element from a tag.
     pub create_element: fn(Cow<'static, str>) -> G,
+    /// Function to create an element from a tag and namespace.
     pub create_element_ns: fn(Cow<'static, str>, Cow<'static, str>) -> G,
 }
 

--- a/packages/sycamore-core/src/lib.rs
+++ b/packages/sycamore-core/src/lib.rs
@@ -8,6 +8,7 @@
 //! - `hydrate` - Enables the hydration API.
 
 #![deny(missing_debug_implementations)]
+#![warn(missing_docs)]
 
 pub mod component;
 pub mod event;

--- a/packages/sycamore-core/src/stable_id.rs
+++ b/packages/sycamore-core/src/stable_id.rs
@@ -1,3 +1,5 @@
+//! Unique IDs that are stable between SSR and hydration.
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// Create a unique ID that's stable between SSR and hydration.

--- a/packages/sycamore-futures/src/lib.rs
+++ b/packages/sycamore-futures/src/lib.rs
@@ -1,6 +1,7 @@
 //! Futures support for reactive scopes.
 
 #![deny(missing_debug_implementations)]
+#![warn(missing_docs)]
 
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -1,6 +1,7 @@
 //! Proc-macros used in [Sycamore](https://sycamore-rs.netlify.app).
 
 #![deny(missing_debug_implementations)]
+#![warn(missing_docs)]
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/packages/sycamore-reactive/src/effects.rs
+++ b/packages/sycamore-reactive/src/effects.rs
@@ -11,12 +11,12 @@ use crate::create_memo;
 /// let state = create_signal(0);
 ///
 /// create_effect(move || {
-///     println!("State changed. New state value = {}", state.get());
+///     println!("new state = {}", state.get());
 /// });
-/// // Prints "State changed. New state value = 0"
+/// // Prints "new state = 0"
 ///
 /// state.set(1);
-/// // Prints "State changed. New state value = 1"
+/// // Prints "new state = 1"
 /// # });
 /// ```
 ///

--- a/packages/sycamore-reactive/src/lib.rs
+++ b/packages/sycamore-reactive/src/lib.rs
@@ -36,6 +36,7 @@
 //! ```
 //! Of course, the stable `.get()` also works on nightly as well if that's what you prefer.
 
+#![warn(missing_docs)]
 #![cfg_attr(feature = "nightly", feature(fn_traits, unboxed_closures))]
 
 mod context;

--- a/packages/sycamore-reactive/src/signals.rs
+++ b/packages/sycamore-reactive/src/signals.rs
@@ -322,6 +322,7 @@ impl<T> Signal<T> {
         self.update(|val| std::mem::replace(val, new))
     }
 
+    /// Silently gets the value of the signal and sets the new value to the default value.
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn take_silent(self) -> T
     where
@@ -330,6 +331,7 @@ impl<T> Signal<T> {
         self.replace_silent(T::default())
     }
 
+    /// Gets the value of the signal and sets the new value to the default value.
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn take(self) -> T
     where
@@ -357,21 +359,26 @@ impl<T> Signal<T> {
         ret
     }
 
+    /// Use a function to produce a new value and sets the value silently.
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn set_fn_silent(self, f: impl FnOnce(&T) -> T) {
         self.update_silent(move |val| *val = f(val));
     }
 
+    /// Use a function to produce a new value and sets the value.
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn set_fn(self, f: impl FnOnce(&T) -> T) {
         self.update_silent(move |val| *val = f(val));
     }
 
+    /// Creates a new [memo](create_memo) from this signal and a function. The resulting memo will
+    /// be created in the current reactive scope.
     #[cfg_attr(debug_assertions, track_caller)]
     pub fn map<U>(self, mut f: impl FnMut(&T) -> U + 'static) -> ReadSignal<U> {
         create_memo(move || self.with(&mut f))
     }
 
+    /// Split the signal into a reader/writter pair.
     pub fn split(self) -> (ReadSignal<T>, impl Fn(T) -> T) {
         (*self, move |value| self.replace(value))
     }

--- a/packages/sycamore-reactive/src/utils.rs
+++ b/packages/sycamore-reactive/src/utils.rs
@@ -51,6 +51,7 @@ pub fn derived<T>(f: impl Fn() -> T) -> impl Accessor<T> {
 ///
 /// Also implemented for tuples containing `Trackable`s.
 pub trait Trackable {
+    /// Track the data reactively.
     fn _track(&self);
 }
 

--- a/packages/sycamore-router-macro/src/lib.rs
+++ b/packages/sycamore-router-macro/src/lib.rs
@@ -1,4 +1,7 @@
+//! Macro support for the `sycamore-router` crate.
+
 #![deny(missing_debug_implementations)]
+#![warn(missing_docs)]
 
 mod parser;
 mod route;

--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -9,6 +9,7 @@
 //! using this crate directly.
 
 #![deny(missing_debug_implementations)]
+#![warn(missing_docs)]
 
 mod dom_node;
 mod dom_node_template;


### PR DESCRIPTION
This adds the `warn(missing_docs)` lint for all the crates and also adds more doctests for reactive signals.