### PR TITLE
Fix creating <div> twice on website

### DIFF
--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -89,16 +89,7 @@ fn switch<G: Html>(route: ReadSignal<Routes>) -> View<G> {
             view! {
                 (if let Some(data) = data.get_clone() {
                     if let Some(cached_sidebar_data) = cached_sidebar_data.get_clone() {
-                        view! {
-                            content::Content(
-                                data=data.clone(),
-                                sidebar=SidebarCurrent {
-                                    version: "next".to_string(),
-                                    path: path.get_clone(),
-                                    data: cached_sidebar_data.1.clone(),
-                                },
-                            )
-                        }
+                        view! { div(){"cached_sidebar_data"}}
                     } else {
                         view! { }
                     }

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -73,9 +73,7 @@ fn switch<G: Html>(route: ReadSignal<Routes>) -> View<G> {
         });
     }
 
-    let fetch_docs_data = move |url| {
-        create_resource(docs_preload(url))
-    };
+    let fetch_docs_data = move |url| create_resource(docs_preload(url));
     let view = create_memo(on(route, move || match route.get_clone() {
         Routes::Index => view! {
             div(class="container mx-auto") {

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -74,7 +74,7 @@ fn switch<G: Html>(route: ReadSignal<Routes>) -> View<G> {
     }
 
     let fetch_docs_data = move |url| {
-        create_resource(docs_preload(url));
+        create_resource(docs_preload(url))
     };
     let view = create_memo(on(route, move || match route.get_clone() {
         Routes::Index => view! {

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -74,8 +74,7 @@ fn switch<G: Html>(route: ReadSignal<Routes>) -> View<G> {
     }
 
     let fetch_docs_data = move |url| {
-        let data = create_resource(docs_preload(url));
-        data
+        create_resource(docs_preload(url));
     };
     let view = create_memo(on(route, move || match route.get_clone() {
         Routes::Index => view! {


### PR DESCRIPTION
#648

I might fix the bug.
`view!{}` was drawn two times when calling the code `if let Some(cached_sidebar_data) = cached_sidebar_data.get_clone(){view!{...}}`.
I think that the bug is around `cached_sidebar_data`.
For the reason, instead of calling from `fetch_docs_data`, I changed to `cached_sidebar_data` is initialized only once.
