### PR TITLE
Update MSVC to 1.73.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.72.0
+          - 1.73.0
           - stable
           - nightly
         os:
@@ -52,8 +52,8 @@ jobs:
         # Only run tests for sycamore to prevent stray feature flags from other tests.
         run: cd packages/sycamore && cargo test
 
-      - name: Run tests (with UI tests) on 1.72.0
-        if: matrix.rust == '1.72.0'
+      - name: Run tests (with UI tests) on 1.73.0
+        if: matrix.rust == '1.73.0'
         env:
           RUN_UI_TESTS: true
         run: cargo test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,16 +147,16 @@ If you want to run the tests in a headless instead, just pass the `--headless` f
 
 #### Macro diagnostics snapshot tests
 
-The proc-macro crates have additional tests for ensuring that we have good diagnostics for common errors. For this, you will need to install the MSRV version of Rust (currently 1.72).
+The proc-macro crates have additional tests for ensuring that we have good diagnostics for common errors. For this, you will need to install the MSRV version of Rust (currently 1.73).
 
 ```bash
-rustup toolchain add 1.72
+rustup toolchain add 1.73
 ```
 
 The macro tests are disabled by default since when running on other versions of Rust, they are usually slightly different and thus would cause a lot of churn. To enable them, set the `RUN_UI_TESTS` env variable to `true`. In addition, if you want to overwrite the existing snapshot, set the `TRYBUILD` env variable to `overwrite`. The final command would look something like:
 
 ```bash
-RUN_UI_TESTS=true TRYBUILD=overwrite cargo +1.72 test
+RUN_UI_TESTS=true TRYBUILD=overwrite cargo +1.73 test
 ```
 
 ## Adding an example

--- a/docs/next/getting_started/installation.md
+++ b/docs/next/getting_started/installation.md
@@ -17,7 +17,7 @@ rustup target add wasm32-unknown-unknown
 
 ### Minimum Supported Rust Version (MSRV) and Rust edition
 
-The minimum supported Rust toolchain is `v1.72.0`. Sycamore is not guaranteed to (and probably
+The minimum supported Rust toolchain is `v1.73.0`. Sycamore is not guaranteed to (and probably
 won't) compile on older versions of Rust.
 
 Sycamore only works on Rust edition 2021. Even though most crates written in edition 2021 are

--- a/packages/sycamore-web/src/ssr_node.rs
+++ b/packages/sycamore-web/src/ssr_node.rs
@@ -145,7 +145,10 @@ impl GenericNode for SsrNode {
     }
 
     fn remove_attribute(&self, name: Cow<'static, str>) {
-        self.unwrap_element().borrow_mut().attributes.remove(&name);
+        self.unwrap_element()
+            .borrow_mut()
+            .attributes
+            .swap_remove(&name);
     }
 
     fn set_class_name(&self, value: Cow<'static, str>) {


### PR DESCRIPTION
Updates the MSVC to 1.73.0 because of `bumpalo`.