### PR TITLE
Update trunk to v0.19.1 and disable minification for hydrate example

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install trunk
         run: >
           wget -qO-
-          https://github.com/thedodd/trunk/releases/download/v0.17.5/trunk-x86_64-unknown-linux-gnu.tar.gz
+          https://github.com/thedodd/trunk/releases/download/v0.19.1/trunk-x86_64-unknown-linux-gnu.tar.gz
           | tar -xzf- && sudo mv trunk /usr/bin/
 
       - name: Cargo generate-lockfile

--- a/.github/workflows/js_framework_bench.yml
+++ b/.github/workflows/js_framework_bench.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install trunk
         run: >
           wget -qO-
-          https://github.com/thedodd/trunk/releases/download/v0.16.0/trunk-x86_64-unknown-linux-gnu.tar.gz
+          https://github.com/thedodd/trunk/releases/download/v0.19.1/trunk-x86_64-unknown-linux-gnu.tar.gz
           | tar -xzf- && sudo mv trunk /usr/bin/
 
       - name: Setup NodeJS

--- a/examples/hydrate/Trunk.toml
+++ b/examples/hydrate/Trunk.toml
@@ -1,0 +1,2 @@
+[build]
+no_minification = true # Disable minification for this example since it interferes with hydration.


### PR DESCRIPTION
Fixes #662 

This PR updates Trunk to v0.19.1 which supports minification of assets. This however breaks the `hydrate` example which relies on hydration markers in the produced HTML file that are removed by minification. To fix this, we disable minification in `examples/hydrate/Trunk.toml`.