### PR TITLE
Add 'SubmitEvent' to re-exported events from web_sys crate

### DIFF
--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -42,8 +42,8 @@ pub mod events {
         AnimationEvent, BeforeUnloadEvent, CompositionEvent, DeviceMotionEvent,
         DeviceOrientationEvent, DragEvent, ErrorEvent, Event, FocusEvent, GamepadEvent,
         HashChangeEvent, KeyboardEvent, MessageEvent, MouseEvent, PageTransitionEvent,
-        PointerEvent, PopStateEvent, ProgressEvent, StorageEvent, TouchEvent, TransitionEvent,
-        UiEvent, WheelEvent,
+        PointerEvent, PopStateEvent, ProgressEvent, StorageEvent, SubmitEvent, TouchEvent,
+        TransitionEvent, UiEvent, WheelEvent,
     };
 }
 


### PR DESCRIPTION
Allows to use `SubmitEvent` type explicitly in closures to fix error when submitting form with `on:submit`.

Currently the following code:
```rust
let submit_fn = move |e: Event| {
    e.prevent_default();
};

view! {
    main(class="container") {
        form(on:submit=submit_fn) {
            button(type="submit") {
                "Submit"
            }
        }
    }
}
```

Will cause error:
```rust
the trait bound `{closure@src/app.rs:41:21: 41:36}: EventHandler<_, submit, _>` is not satisfied
the trait `EventHandler<_, submit, _>` is not implemented for closure `{closure@src/app.rs:41:21: 41:36}`rustc[...](...)
app.rs(45, 5): required by a bound introduced by this call
generic_node.rs(128, 12): required by a bound in `event`
```

Defining function with empty closure `let submit_fn = move|_| {...}` infers to `impl Fn(SubmitEvent)` but you can't call `e.prevent_default()` that prevents page refresh on submitting forms. 

Unless there's better way to do it (like implementing, this simple re-export of `SubmitEvent` fixes the problem by allowing explicit type definition. This refactored function now compiles and works as expected:
```rust
let submit_fn = move |e: SubmitEvent| {
    e.prevent_default();
};
``` 