### PR TITLE
Replace CountAPI as it got taken down. 

### DIFF
--- a/examples/http-request-builder/src/main.rs
+++ b/examples/http-request-builder/src/main.rs
@@ -6,7 +6,7 @@ use sycamore::prelude::*;
 use sycamore::suspense::{Suspense, SuspenseProps};
 
 // API that counts visits to the web-page
-const API_BASE_URL: &str = "https://api.countapi.xyz/hit";
+const API_BASE_URL: &str = "https://abacus.jasoncameron.dev/hit";
 
 #[derive(Serialize, Deserialize, Default, Debug)]
 struct Visits {

--- a/examples/http-request/src/main.rs
+++ b/examples/http-request/src/main.rs
@@ -4,7 +4,7 @@ use sycamore::prelude::*;
 use sycamore::suspense::Suspense;
 
 // API that counts visits to the web-page
-const API_BASE_URL: &str = "https://api.countapi.xyz/hit";
+const API_BASE_URL: &str = "https://abacus.jasoncameron.dev/hit";
 
 #[derive(Serialize, Deserialize, Default, Debug)]
 struct Visits {


### PR DESCRIPTION
Replaced CountAPI as it got bought out then taken down by APILayer, this is a fully compliant replacement for it. 

This code was created in https://github.com/sycamore-rs/sycamore/pull/305