### PR TITLE
Make `ViewHtmlNode` methods use `Cow<'static, str>` instead of `&'static str`

### DIFF
--- a/packages/sycamore-web/src/elements.rs
+++ b/packages/sycamore-web/src/elements.rs
@@ -1144,7 +1144,7 @@ pub trait GlobalAttributes: IntoHtmlNode + Sized {
         let scope = use_current_scope(); // Run handler inside the current scope.
         let handler = move |ev: web_sys::Event| scope.run_in(|| handler.call(ev.unchecked_into()));
         let node = self.as_html_node_mut();
-        node.set_event_handler(T::NAME, handler);
+        node.set_event_handler(T::NAME.into(), handler);
         self
     }
 
@@ -1159,7 +1159,7 @@ pub trait GlobalAttributes: IntoHtmlNode + Sized {
                 signal.set(T::CONVERT_FROM_JS(&value).expect("failed to convert value from js"));
             })
         };
-        node.set_event_handler(<T::Event as events::EventDescriptor>::NAME, handler);
+        node.set_event_handler(<T::Event as events::EventDescriptor>::NAME.into(), handler);
 
         self.prop(T::TARGET_PROPERTY, move || signal.get_clone().into())
     }

--- a/packages/sycamore-web/src/node/hydrate.rs
+++ b/packages/sycamore-web/src/node/hydrate.rs
@@ -175,7 +175,7 @@ impl ViewHtmlNode for HydrateNode {
         Self(NodeState::Marker(DomNode::create_marker_node()))
     }
 
-    fn set_attribute(&mut self, name: &'static str, value: MaybeDynString) {
+    fn set_attribute(&mut self, name: Cow<'static, str>, value: MaybeDynString) {
         // FIXME: use setAttributeNS if SVG
         if IS_HYDRATING.get() {
             match value {
@@ -190,7 +190,7 @@ impl ViewHtmlNode for HydrateNode {
                     create_effect_initial(move || {
                         let _ = f(); // Track dependencies of f.
                         (
-                            Box::new(move || node.set_attribute(name, &f()).unwrap()),
+                            Box::new(move || node.set_attribute(&name, &f()).unwrap()),
                             (),
                         )
                     });
@@ -201,7 +201,7 @@ impl ViewHtmlNode for HydrateNode {
         }
     }
 
-    fn set_bool_attribute(&mut self, name: &'static str, value: MaybeDynBool) {
+    fn set_bool_attribute(&mut self, name: Cow<'static, str>, value: MaybeDynBool) {
         // FIXME: use setAttributeNS if SVG
         if IS_HYDRATING.get() {
             match value {
@@ -218,9 +218,9 @@ impl ViewHtmlNode for HydrateNode {
                         (
                             Box::new(move || {
                                 if f() {
-                                    node.set_attribute(name, "").unwrap();
+                                    node.set_attribute(&name, "").unwrap();
                                 } else {
-                                    node.remove_attribute(name).unwrap();
+                                    node.remove_attribute(&name).unwrap();
                                 }
                             }),
                             (),
@@ -233,13 +233,13 @@ impl ViewHtmlNode for HydrateNode {
         }
     }
 
-    fn set_property(&mut self, name: &'static str, value: MaybeDynJsValue) {
+    fn set_property(&mut self, name: Cow<'static, str>, value: MaybeDynJsValue) {
         self.0.unwrap_mut().set_property(name, value);
     }
 
     fn set_event_handler(
         &mut self,
-        name: &'static str,
+        name: Cow<'static, str>,
         handler: impl FnMut(web_sys::Event) + 'static,
     ) {
         self.0.unwrap_mut().set_event_handler(name, handler);

--- a/packages/sycamore-web/src/node/mod.rs
+++ b/packages/sycamore-web/src/node/mod.rs
@@ -43,15 +43,15 @@ pub trait ViewHtmlNode: ViewNode {
     fn create_marker_node() -> Self;
 
     /// Set an HTML attribute.
-    fn set_attribute(&mut self, name: &'static str, value: MaybeDynString);
+    fn set_attribute(&mut self, name: Cow<'static, str>, value: MaybeDynString);
     /// Set a boolean HTML attribute.
-    fn set_bool_attribute(&mut self, name: &'static str, value: MaybeDynBool);
+    fn set_bool_attribute(&mut self, name: Cow<'static, str>, value: MaybeDynBool);
     /// Set a JS property on an element.
-    fn set_property(&mut self, name: &'static str, value: MaybeDynJsValue);
+    fn set_property(&mut self, name: Cow<'static, str>, value: MaybeDynJsValue);
     /// Set an event handler on an element.
     fn set_event_handler(
         &mut self,
-        name: &'static str,
+        name: Cow<'static, str>,
         handler: impl FnMut(web_sys::Event) + 'static,
     );
     /// Set the inner HTML value of an element.
@@ -79,19 +79,19 @@ pub trait AttributeValue {
 
 impl AttributeValue for MaybeDynString {
     fn set_self(self, el: &mut HtmlNode, name: &'static str) {
-        el.set_attribute(name, self);
+        el.set_attribute(name.into(), self);
     }
 }
 
 impl AttributeValue for MaybeDynBool {
     fn set_self(self, el: &mut HtmlNode, name: &'static str) {
-        el.set_bool_attribute(name, self);
+        el.set_bool_attribute(name.into(), self);
     }
 }
 
 impl AttributeValue for MaybeDynJsValue {
     fn set_self(self, el: &mut HtmlNode, name: &'static str) {
-        el.set_property(name, self);
+        el.set_property(name.into(), self);
     }
 }
 

--- a/packages/sycamore-web/src/node/ssr.rs
+++ b/packages/sycamore-web/src/node/ssr.rs
@@ -8,8 +8,8 @@ use crate::*;
 pub enum SsrNode {
     Element {
         tag: Cow<'static, str>,
-        attributes: Vec<(&'static str, Cow<'static, str>)>,
-        bool_attributes: Vec<(&'static str, bool)>,
+        attributes: Vec<(Cow<'static, str>, Cow<'static, str>)>,
+        bool_attributes: Vec<(Cow<'static, str>, bool)>,
         children: Vec<Self>,
         inner_html: Option<Cow<'static, str>>,
         hk_key: Option<u32>,
@@ -96,14 +96,14 @@ impl ViewHtmlNode for SsrNode {
         Self::Marker
     }
 
-    fn set_attribute(&mut self, name: &'static str, value: MaybeDynString) {
+    fn set_attribute(&mut self, name: Cow<'static, str>, value: MaybeDynString) {
         match self {
             Self::Element { attributes, .. } => attributes.push((name, value.evaluate())),
             _ => panic!("can only set attribute on an element"),
         }
     }
 
-    fn set_bool_attribute(&mut self, name: &'static str, value: MaybeDynBool) {
+    fn set_bool_attribute(&mut self, name: Cow<'static, str>, value: MaybeDynBool) {
         match self {
             Self::Element {
                 bool_attributes, ..
@@ -112,13 +112,13 @@ impl ViewHtmlNode for SsrNode {
         }
     }
 
-    fn set_property(&mut self, _name: &'static str, _value: MaybeDynJsValue) {
+    fn set_property(&mut self, _name: Cow<'static, str>, _value: MaybeDynJsValue) {
         // Noop in SSR mode.
     }
 
     fn set_event_handler(
         &mut self,
-        _name: &'static str,
+        _name: Cow<'static, str>,
         _handler: impl FnMut(web_sys::Event) + 'static,
     ) {
         // Noop in SSR mode.


### PR DESCRIPTION
This change allows setting non `&'static str` values as attribute names, such as when programmatically building up the view tree from serialized data.