### PR TITLE
Remove `nom` dependency and replace with hand written parser

### DIFF
--- a/packages/sycamore-router-macro/Cargo.toml
+++ b/packages/sycamore-router-macro/Cargo.toml
@@ -16,11 +16,9 @@ proc-macro = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-nom = "7.1.1"
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
 syn = "2.0.10"
-unicode-xid = "0.2.4"
 
 [dev-dependencies]
 expect-test = "1.4.0"

--- a/packages/sycamore-router-macro/src/parser.rs
+++ b/packages/sycamore-router-macro/src/parser.rs
@@ -35,9 +35,13 @@ pub fn parse_route(i: &str) -> Result<RoutePathAst> {
     for segment in segments {
         if segment.starts_with('<') {
             if segment.ends_with("..>") {
-                segments_ast.push(SegmentAst::DynSegments(segment[1..segment.len() - 3].to_string()));
+                segments_ast.push(SegmentAst::DynSegments(
+                    segment[1..segment.len() - 3].to_string(),
+                ));
             } else if segment.ends_with('>') {
-                segments_ast.push(SegmentAst::DynParam(segment[1..segment.len() - 1].to_string()));
+                segments_ast.push(SegmentAst::DynParam(
+                    segment[1..segment.len() - 1].to_string(),
+                ));
             } else {
                 return Err(ParseError {
                     message: "missing `>` in dynamic segment".to_string(),
@@ -49,7 +53,7 @@ pub fn parse_route(i: &str) -> Result<RoutePathAst> {
             // Do not return this error if we are matching the index page ("/").
             return Err(ParseError {
                 message: "segment cannot be empty".to_string(),
-            })
+            });
         }
     }
 

--- a/packages/sycamore-router-macro/src/route.rs
+++ b/packages/sycamore-router-macro/src/route.rs
@@ -4,7 +4,7 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{DeriveInput, Fields, Ident, LitStr, Token, Variant};
 
-use crate::parser::{route, RoutePathAst, SegmentAst};
+use crate::parser::{parse_route, RoutePathAst, SegmentAst};
 
 pub fn route_impl(input: DeriveInput) -> syn::Result<TokenStream> {
     let mut quoted = TokenStream::new();
@@ -36,13 +36,12 @@ pub fn route_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                             // region: parse route
                             let route_litstr: LitStr = attr.parse_args()?;
                             let route_str = route_litstr.value();
-                            let route = match route(&route_str) {
-                                Ok(("", route_ast)) => route_ast,
-                                Ok((_, _)) => unreachable!("parser error"),
-                                Err(_err) => {
+                            let route = match parse_route(&route_str) {
+                                Ok(route_ast) => route_ast,
+                                Err(err) => {
                                     return Err(syn::Error::new(
                                         route_litstr.span(),
-                                        "route is malformed",
+                                        err.message
                                     ));
                                 }
                             };

--- a/packages/sycamore-router-macro/src/route.rs
+++ b/packages/sycamore-router-macro/src/route.rs
@@ -39,10 +39,7 @@ pub fn route_impl(input: DeriveInput) -> syn::Result<TokenStream> {
                             let route = match parse_route(&route_str) {
                                 Ok(route_ast) => route_ast,
                                 Err(err) => {
-                                    return Err(syn::Error::new(
-                                        route_litstr.span(),
-                                        err.message
-                                    ));
+                                    return Err(syn::Error::new(route_litstr.span(), err.message));
                                 }
                             };
                             // endregion

--- a/packages/sycamore-router-macro/tests/router/router-fail.rs
+++ b/packages/sycamore-router-macro/tests/router/router-fail.rs
@@ -45,12 +45,4 @@ enum Routes7 {
     NotFound,
 }
 
-#[derive(Route)]
-enum Routes8 {
-    #[to("<a/b>")] // `a/b` is not an identifier
-    Path { a: u32 },
-    #[not_found]
-    NotFound,
-}
-
 fn main() {}

--- a/packages/sycamore-router-macro/tests/router/router-fail.stderr
+++ b/packages/sycamore-router-macro/tests/router/router-fail.stderr
@@ -41,9 +41,3 @@ error: capture field name mismatch (expected `a`, found `b`)
    |
 43 |     Path { b: u32, a: u32 }, // Wrong order
    |            ^
-
-error: mismatch between number of capture fields and variant fields (found 0 capture field(s) and 1 variant field(s))
-  --> tests/router/router-fail.rs:51:10
-   |
-51 |     Path { a: u32 },
-   |          ^^^^^^^^^^


### PR DESCRIPTION
This PR removes a few dependencies from `sycamore-router-macro` which should improve compile times.