### PR TITLE
Fix suspense rendering async shell during fallback

### DIFF
--- a/packages/sycamore-web/Cargo.toml
+++ b/packages/sycamore-web/Cargo.toml
@@ -28,6 +28,7 @@ web-sys = { version = "0.3.69", features = [
 	"NodeList",
 	"Window",
 	"Document",
+	"DocumentFragment",
 	"Element",
 	"EventListener",
 	"HtmlElement",

--- a/packages/sycamore-web/src/iter.rs
+++ b/packages/sycamore-web/src/iter.rs
@@ -117,7 +117,7 @@ where
                     Box::new(move || {
                         // Get all nodes between start and end and reconcile with new nodes.
                         let mut new = flattened.get_clone();
-                        let mut old = get_nodes_between(&start_node, &end_node);
+                        let mut old = utils::get_nodes_between(&start_node, &end_node);
                         // We must include the end node in case `old` is empty (precondition for
                         // reconcile_fragments).
                         new.push(end_node.clone());
@@ -217,7 +217,7 @@ where
                     Box::new(move || {
                         // Get all nodes between start and end and reconcile with new nodes.
                         let mut new = flattened.get_clone();
-                        let mut old = get_nodes_between(&start_node, &end_node);
+                        let mut old = utils::get_nodes_between(&start_node, &end_node);
                         // We must include the end node in case `old` is empty (precondition for
                         // reconcile_fragments).
                         new.push(end_node.clone());
@@ -429,34 +429,4 @@ fn reconcile_fragments(parent: &web_sys::Node, a: &mut [web_sys::Node], b: &[web
             }
         }
     }
-}
-
-/// Get all nodes between `start` and `end`.
-///
-/// If `end` is before `start`, all nodes after `start` will be returned.
-///
-/// The range is exclusive so `start` and `end` will not be included.
-#[must_use]
-pub(crate) fn get_nodes_between(start: &web_sys::Node, end: &web_sys::Node) -> Vec<web_sys::Node> {
-    let parent = start.parent_node().unwrap();
-    debug_assert_eq!(
-        parent,
-        end.parent_node().unwrap(),
-        "parents of `start` and `end` do not match"
-    );
-
-    let mut nodes = Vec::new();
-
-    let mut next = start.next_sibling();
-    while let Some(current) = next {
-        let tmp = current.next_sibling();
-        if &current == end {
-            break;
-        } else {
-            nodes.push(current);
-        }
-        next = tmp;
-    }
-
-    nodes
 }

--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -47,7 +47,9 @@ mod portal;
 mod stable_counter;
 #[cfg(feature = "suspense")]
 mod suspense;
-mod view;
+mod utils;
+
+pub(crate) mod view;
 
 pub use self::attributes::*;
 pub use self::components::*;

--- a/packages/sycamore-web/src/node/dom_node.rs
+++ b/packages/sycamore-web/src/node/dom_node.rs
@@ -66,7 +66,7 @@ pub(crate) fn _create_dynamic_view<T: ViewHtmlNode, U: Into<View<T>> + 'static>(
                     let new = f().into();
                     if let Some(parent) = start_node.parent_node() {
                         // Clear all the old nodes away.
-                        let old = iter::get_nodes_between(&start_node, &end_node);
+                        let old = utils::get_nodes_between(&start_node, &end_node);
                         for node in old {
                             parent.remove_child(&node).unwrap();
                         }
@@ -76,6 +76,8 @@ pub(crate) fn _create_dynamic_view<T: ViewHtmlNode, U: Into<View<T>> + 'static>(
                                 .insert_before(node.as_web_sys(), Some(&end_node))
                                 .unwrap();
                         }
+                    } else if cfg!(debug_assertions) {
+                        console_warn!("cannot update a dynamic view if it is not mounted");
                     }
                 }),
                 view,

--- a/packages/sycamore-web/src/node/ssr_render.rs
+++ b/packages/sycamore-web/src/node/ssr_render.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+/// The mode in which SSR is being run.
+pub enum SsrMode {
+    /// Synchronous mode.
+    ///
+    /// When a suspense boundary is hit, only the fallback is rendered.
+    Sync,
+    /// Streaming mode.
+    ///
+    /// When a suspense boundary is hit, the fallback is never rendered. Instead, a special SSR
+    /// Suspense node is created that contains a future resolving to the async content.
+    Streaming,
+}
+
 /// Render a [`View`] into a static [`String`]. Useful for rendering to a string on the server side.
 #[must_use]
 pub fn render_to_string(view: impl FnOnce() -> View) -> String {

--- a/packages/sycamore-web/src/portal.rs
+++ b/packages/sycamore-web/src/portal.rs
@@ -23,7 +23,7 @@ pub fn Portal<'a, T: Into<View> + Default>(selector: &'a str, children: T) -> Vi
         }
 
         on_cleanup(move || {
-            let nodes = get_nodes_between(&start_node, &end_node);
+            let nodes = utils::get_nodes_between(&start_node, &end_node);
             for node in nodes {
                 parent.remove_child(&node).unwrap();
             }

--- a/packages/sycamore-web/src/suspense.rs
+++ b/packages/sycamore-web/src/suspense.rs
@@ -49,18 +49,23 @@ pub fn Suspense(props: SuspenseProps) -> View {
     let SuspenseProps { fallback, children } = props;
     let mut fallback = Some(fallback);
 
-    let show = create_signal(false);
-    let (view, suspend) = await_suspense(move || children.call());
-    // If the Suspense is nested under another Suspense, we want the other Suspense to await this
-    // one as well.
-    suspense_scope(async move {
-        suspend.await;
-        show.set(true);
-    });
+    if is_ssr!() {
+        // TODO: for now, SSR only supports sync rendering so just return the fallback.
+        fallback.take().unwrap()
+    } else {
+        let show = create_signal(false);
+        let (view, suspend) = await_suspense(move || children.call());
+        // If the Suspense is nested under another Suspense, we want the other Suspense to await
+        // this one as well.
+        suspense_scope(async move {
+            suspend.await;
+            show.set(true);
+        });
 
-    let mut view = Some(utils::wrap_in_document_fragment(view));
-    view! {
-        (if !show.get() { fallback.take().unwrap() } else { view.take().unwrap() })
+        let mut view = Some(utils::wrap_in_document_fragment(view));
+        view! {
+            (if !show.get() { fallback.take().unwrap() } else { view.take().unwrap() })
+        }
     }
 }
 

--- a/packages/sycamore-web/src/suspense.rs
+++ b/packages/sycamore-web/src/suspense.rs
@@ -58,9 +58,9 @@ pub fn Suspense(props: SuspenseProps) -> View {
         show.set(true);
     });
 
+    let mut view = Some(utils::wrap_in_document_fragment(view));
     view! {
-        (view)
-        (if !show.get() { fallback.take().unwrap() } else { View::default() })
+        (if !show.get() { fallback.take().unwrap() } else { view.take().unwrap() })
     }
 }
 

--- a/packages/sycamore-web/src/utils.rs
+++ b/packages/sycamore-web/src/utils.rs
@@ -1,0 +1,52 @@
+use crate::*;
+
+/// Get all nodes between `start` and `end`.
+///
+/// If `end` is before `start`, all nodes after `start` will be returned.
+///
+/// The range is exclusive so `start` and `end` will not be included.
+#[must_use]
+pub fn get_nodes_between(start: &web_sys::Node, end: &web_sys::Node) -> Vec<web_sys::Node> {
+    let parent = start.parent_node().unwrap();
+    debug_assert_eq!(
+        parent,
+        end.parent_node().unwrap(),
+        "parents of `start` and `end` do not match"
+    );
+
+    let mut nodes = Vec::new();
+
+    let mut next = start.next_sibling();
+    while let Some(current) = next {
+        let tmp = current.next_sibling();
+        if &current == end {
+            break;
+        } else {
+            nodes.push(current);
+        }
+        next = tmp;
+    }
+
+    nodes
+}
+
+/// Wrap all the nodes in a [`View`] in a document fragment.
+///
+/// This is useful when the view is dynamically changed without being mounted since this will not
+/// update the DOM. Wrapping the nodes in a document fragment will allow you to dynamically update
+/// the view while it is detatched, and then insert it into the DOM later.
+///
+/// This only works on the client side.
+pub fn wrap_in_document_fragment(view: View) -> View {
+    let fragment = web_sys::window()
+        .unwrap()
+        .document()
+        .unwrap()
+        .create_document_fragment();
+
+    for node in view.as_web_sys() {
+        fragment.append_child(&node).unwrap();
+    }
+
+    View::from_node(HtmlNode::from_web_sys(fragment.into()))
+}


### PR DESCRIPTION
There was a subtle bug introduced in #679 regarding suspense support:

```rust
view! {
    Suspense(fallback=view! { "Loading..." }) {
        "Test"
        AsyncComponent()
    }
}
```

Would render the text `"TestLoading..."`.

This is because we don't support dynamically updating views when they are detached from the DOM. This used to fail silently but now will trigger a warning in the console.

This PR fixes this issue by first rendering the async view into a document fragment and then appending that document fragment when suspense is resolved.