### PR TITLE
Fix router on different pathname and hash triggers hard refresh

### DIFF
--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -81,9 +81,7 @@ impl Integration for HistoryIntegration {
 
                 let meta_keys_pressed = meta_keys_pressed(ev.unchecked_ref::<KeyboardEvent>());
                 if !meta_keys_pressed && location.origin() == Ok(origin) {
-                    if location.hash().as_ref() != Ok(&hash) {
-                        // Same origin, same path, different anchor. Use default browser behavior.
-                    } else if location.pathname().as_ref() != Ok(&a_pathname) {
+                    if location.pathname().as_ref() != Ok(&a_pathname) {
                         // Same origin, different path. Navigate to new page.
                         ev.prevent_default();
                         PATHNAME.with(|pathname| {
@@ -100,6 +98,8 @@ impl Integration for HistoryIntegration {
                                 .unwrap_throw();
                             window().scroll_to_with_x_and_y(0.0, 0.0);
                         });
+                    } else if location.hash().as_ref() != Ok(&hash) {
+                        // Same origin, same pathname, different hash. Use default browser behavior.
                     } else {
                         // Same page. Do nothing.
                         ev.prevent_default();


### PR DESCRIPTION
Fixes a bug where navigating to a different pathname with a different hash triggers a browser refresh.

Instead, the router should intercept this and handle the navigation.