### PR TITLE
Update branch name from `master` to `main`

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -2,7 +2,7 @@ name: Build website
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   deploy:

--- a/.github/workflows/continuous_bench.yml
+++ b/.github/workflows/continuous_bench.yml
@@ -2,8 +2,7 @@ name: Continuous benchmark
 
 on:
   push:
-    branches:
-      - master
+    branches: [main]
 
 jobs:
   bench:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,9 +2,9 @@ name: Coverage
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   coverage:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "**/*.rs"
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "**/*.rs"
 jobs:

--- a/.github/workflows/js_framework_bench.yml
+++ b/.github/workflows/js_framework_bench.yml
@@ -2,7 +2,7 @@ name: JS framework benchmark
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
     types: [labeled, synchronize]
 
 jobs:

--- a/.github/workflows/post_js_framework_bench.yml
+++ b/.github/workflows/post_js_framework_bench.yml
@@ -3,8 +3,7 @@ name: Post comment for JS framework benchmark
 on:
   workflow_run:
     workflows: [JS framework benchmark]
-    types:
-      - completed
+    types: [completed]
 
 jobs:
   post-js-framework-benchmark-comment-results:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 First, thank you for wanting to contribute! Sycamore is completely free and open-source and could not be so without the help of contributors like you!
 
-Check out our community's [Code of Conduct](https://github.com/sycamore-rs/sycamore/blob/master/CODE_OF_CONDUCT.md) and feel free to say hello on our [Discord server](https://discord.gg/vDwFUmm6mU) if you like. We have a special channel dedicated to Sycamore development where you can ask questions and guidance as well as geting to know other users and contributors of Sycamore in an informal setting.
+Check out our community's [Code of Conduct](https://github.com/sycamore-rs/sycamore/blob/main/CODE_OF_CONDUCT.md) and feel free to say hello on our [Discord server](https://discord.gg/vDwFUmm6mU) if you like. We have a special channel dedicated to Sycamore development where you can ask questions and guidance as well as geting to know other users and contributors of Sycamore in an informal setting.
 
 The rest of this document will contain:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Sycamore is extensively documented:
 ## Examples
 
 Sycamore has many examples for your reference in the
-[`examples/`](https://github.com/sycamore-rs/sycamore/tree/master/examples) directory. Be sure to
+[`examples/`](https://github.com/sycamore-rs/sycamore/tree/main/examples) directory. Be sure to
 check them out!
 
 ### Viewing on `sycamore-rs.netlify.app`

--- a/docs/next/getting_started/faq.md
+++ b/docs/next/getting_started/faq.md
@@ -3,7 +3,7 @@
 ## I'm new to Sycamore. Where should I start?
 
 If you like getting your hands dirty, try playing around with some
-[examples](https://github.com/sycamore-rs/sycamore/tree/master/examples).
+[examples](https://github.com/sycamore-rs/sycamore/tree/main/examples).
 
 If you prefer reading documentation, consider working your way through the
 [Sycamore Book](../getting_started/installation).

--- a/docs/next/getting_started/installation.md
+++ b/docs/next/getting_started/installation.md
@@ -71,7 +71,7 @@ sycamore = "0.9.0-beta.4"
 >
 > However, breaking changes are introduced all the time. It is therefore recommended to also specify
 > a specific commit hash to prevent your code from randomly breaking. You can find the latest commit
-> hash [here](https://github.com/sycamore-rs/sycamore/commits/master) (to the right of each commit).
+> hash [here](https://github.com/sycamore-rs/sycamore/commits/main) (to the right of each commit).
 >
 > ```toml
 > # Make sure you update the rev to the latest commit hash.

--- a/docs/src/main.rs
+++ b/docs/src/main.rs
@@ -212,7 +212,7 @@ fn generate_sitemap_xml() -> Result<(), Box<dyn Error>> {
     // News
     generate_sitemap_for_dir(&mut buf, "/news", Path::new("posts"), "yearly", "0.8")?;
 
-    // Docs for master
+    // Docs for main
     generate_sitemap_for_dir(&mut buf, "/docs", Path::new("./next"), "weekly", "0.5")?;
 
     // Versioned docs

--- a/packages/tools/bench-diff/src/main.rs
+++ b/packages/tools/bench-diff/src/main.rs
@@ -70,7 +70,7 @@ fn main() {
 
     println!("### Benchmark Report");
     println!("- `wasm-bindgen`: the performance goal");
-    println!("- `baseline`: performance of `sycamore-baseline` (typically latest master)");
+    println!("- `baseline`: performance of `sycamore-baseline` (typically latest main)");
     println!("- `update`: performance of `sycamore` (typically recent changes)");
     println!("- `diff`: measures the improvement of `update` over the `baseline`");
     println!("```diff");


### PR DESCRIPTION
Updates workflows and documentation by replacing instances of `master` with `main`.