### PR TITLE
Allow attribute names by using string literal

### DIFF
--- a/docs/next/basics/view.md
+++ b/docs/next/basics/view.md
@@ -93,7 +93,7 @@ Attributes (including classes and ids) can also be specified.
 
 ```rust
 view! {
-    p(class="my-class", id="my-paragraph", aria-label="My paragraph")
+    p(class="my-class", id="my-paragraph", aria-label="My paragraph", "attr-42"="foo")
     button(disabled=true) {
        "My button"
     }

--- a/packages/sycamore-macro/src/view.rs
+++ b/packages/sycamore-macro/src/view.rs
@@ -105,6 +105,9 @@ impl Codegen {
             PropType::PlainHyphenated { ident } => {
                 quote! { .attr(#ident, #dyn_value) }
             }
+            PropType::PlainQuoted { ident } => {
+                quote! { .attr(#ident, #dyn_value) }
+            }
             PropType::Directive { dir, ident } => match dir.to_string().as_str() {
                 "on" => quote! { .on(::sycamore::rt::events::#ident, #value) },
                 "prop" => {

--- a/packages/sycamore-macro/tests/view/element-pass.rs
+++ b/packages/sycamore-macro/tests/view/element-pass.rs
@@ -10,6 +10,7 @@ fn compile_pass() {
 
         let _: View = view! { p(class="my-class") };
         let _: View = view! { p(class="my-class", id="my-id") };
+        let _: View = view! { p("attr-42"="my-value") };
 
         let _: View = view! { button(class="my-btn", on:click=|_| {}) };
         let _: View = view! { button(class="my-btn", aria-hidden="true") };

--- a/packages/sycamore-view-parser/src/ir.rs
+++ b/packages/sycamore-view-parser/src/ir.rs
@@ -53,6 +53,8 @@ pub enum PropType {
     Plain { ident: Ident },
     /// Syntax: `<hyphenated-name>=<expr>`.
     PlainHyphenated { ident: String },
+    /// Syntax: `"<quoted-name>"=<expr>`.
+    PlainQuoted { ident: String },
     /// Syntax: `<dir>:<prop>=<expr>`.
     Directive { dir: Ident, ident: Ident },
     /// Syntax: `ref=<expr>`.

--- a/packages/sycamore-view-parser/src/parse.rs
+++ b/packages/sycamore-view-parser/src/parse.rs
@@ -153,6 +153,9 @@ impl Parse for PropType {
                     Ok(Self::Plain { ident: name })
                 }
             }
+        } else if lookahead.peek(LitStr) {
+            let name: String = <LitStr as Parse>::parse(input).map(|s| s.value())?;
+            Ok(Self::PlainQuoted { ident: name })
         } else {
             Err(lookahead.error())
         }


### PR DESCRIPTION
Added a new PropType variant and the corresponding updates to parsing and dom manipulation. 

Added 1 case into 'element-pass' test using such quoted-string attribute.

Updated docs to show usage of "quoted string-literal" attribute name.

Note, that the issue #703 says _"Allow arbitrary attribute names by using string literal."_, but we are using [web_sys::Element::set_attribute](https://github.com/sycamore-rs/sycamore/blob/b6577326590257fef8268184d547ecce840b3d2a/packages/sycamore-web/src/node/dom_node.rs#L119), and that call will panic if you try to set attribute name to something illegal. It seems to get upset by anything except alphanumeric characters, underscores or non-leading-dashes.

But at least now you can add such horrible, but valid attributes, if needed:

```rust
button("hello-22--"="no-way") {}
```
