### PR TITLE
Add re-exports back to `sycamore-web`

### DIFF
--- a/examples/js-framework-benchmark/Cargo.toml
+++ b/examples/js-framework-benchmark/Cargo.toml
@@ -10,4 +10,3 @@ console_error_panic_hook = "0.1.7"
 getrandom = { version = "0.2.8", features = ["js"] }
 rand = "0.8.5"
 sycamore = { path = "../../packages/sycamore" }
-web-sys = "0.3.60"

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -13,7 +13,6 @@ serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 sycamore = { path = "../../packages/sycamore", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4", "js"] }
-wasm-bindgen = "0.2.92"
 
 [dependencies.web-sys]
 features = ["Location", "Storage", "HtmlInputElement"]

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sycamore::prelude::*;
+use sycamore::web::wasm_bindgen::prelude::*;
 use uuid::Uuid;
-use wasm_bindgen::prelude::*;
 use web_sys::{HtmlInputElement, KeyboardEvent};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]

--- a/packages/sycamore-reactive/src/maybe_dyn.rs
+++ b/packages/sycamore-reactive/src/maybe_dyn.rs
@@ -13,9 +13,9 @@ use crate::*;
 ///
 /// # Creating a `MaybeDyn`
 ///
-/// You can create a `MaybeDyn` from a static value by using the [`Static`] variant. However, most
-/// of the times, you probably want to use the implementation of the `From<U>` trait for
-/// `MaybeDyn<T>`.
+/// You can create a `MaybeDyn` from a static value by using the [`MaybeDyn::Static`] variant.
+/// However, most of the times, you probably want to use the implementation of the `From<U>` trait
+/// for `MaybeDyn<T>`.
 ///
 /// This trait is already implemented globally for signals and closures that return `T`. However,
 /// we cannot provide a blanket implementation for all types `T` to convert into `MaybeDyn<T>`
@@ -34,8 +34,8 @@ where
 }
 
 impl<T: Into<Self> + 'static> MaybeDyn<T> {
-    /// Get the value by consuming itself. Unlike [`get_clone`], this method avoids a clone if we
-    /// are just storing a static value.
+    /// Get the value by consuming itself. Unlike [`get_clone`](Self::get_clone), this method avoids
+    /// a clone if we are just storing a static value.
     pub fn evaluate(self) -> T
     where
         T: Clone,

--- a/packages/sycamore-web/src/events.rs
+++ b/packages/sycamore-web/src/events.rs
@@ -3,7 +3,7 @@
 #[cfg(feature = "suspense")]
 use sycamore_futures::spawn_local_scoped;
 use wasm_bindgen::JsCast;
-use web_sys::{
+pub use web_sys::{
     AnimationEvent, BeforeUnloadEvent, CompositionEvent, DeviceMotionEvent, DeviceOrientationEvent,
     DragEvent, ErrorEvent, Event, FocusEvent, GamepadEvent, HashChangeEvent, InputEvent,
     KeyboardEvent, MessageEvent, MouseEvent, PageTransitionEvent, PointerEvent, PopStateEvent,

--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -82,6 +82,10 @@ pub mod rt {
     pub use crate::{bind, custom_element, tags, View};
 }
 
+/// Re-export of `js-sys` and `wasm-bindgen` for convenience.
+//#[doc(no_inline)]
+pub use {js_sys, wasm_bindgen};
+
 /// A macro that expands to whether we are in SSR mode or not.
 ///
 /// Can also be used with a block to only include the code inside the block if in SSR mode.


### PR DESCRIPTION
Somehow they got removed at some point (probably during #679)