### PR TITLE
Cleanup some example dependencies

### DIFF
--- a/examples/hello-builder/Cargo.toml
+++ b/examples/hello-builder/Cargo.toml
@@ -7,6 +7,4 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
-log = "0.4.17"
 sycamore = { path = "../../packages/sycamore" }

--- a/examples/hello-builder/src/main.rs
+++ b/examples/hello-builder/src/main.rs
@@ -30,7 +30,5 @@ fn App() -> View {
 
 fn main() {
     console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Debug).unwrap();
-
     sycamore::render(App);
 }

--- a/examples/http-request-builder/Cargo.toml
+++ b/examples/http-request-builder/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-reqwasm = "0.5.0"
+gloo-net = { version = "0.6.0", features = ["http"] }
 serde = "1.0.147"
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }

--- a/examples/http-request-builder/Cargo.toml
+++ b/examples/http-request-builder/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
-log = "0.4.17"
 reqwasm = "0.5.0"
 serde = "1.0.147"
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }

--- a/examples/http-request-builder/src/main.rs
+++ b/examples/http-request-builder/src/main.rs
@@ -45,7 +45,5 @@ fn App() -> View {
 
 fn main() {
     console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Debug).unwrap();
-
     sycamore::render(App);
 }

--- a/examples/http-request-builder/src/main.rs
+++ b/examples/http-request-builder/src/main.rs
@@ -1,4 +1,4 @@
-use reqwasm::http::Request;
+use gloo_net::http::Request;
 use serde::{Deserialize, Serialize};
 use sycamore::prelude::*;
 use sycamore::web::tags::*;
@@ -12,7 +12,7 @@ struct Visits {
     value: u64,
 }
 
-async fn fetch_visits(id: &str) -> Result<Visits, reqwasm::Error> {
+async fn fetch_visits(id: &str) -> Result<Visits, gloo_net::Error> {
     let url = format!("{API_BASE_URL}/{id}/http-request-builder");
     let resp = Request::get(&url).send().await?;
 

--- a/examples/http-request/Cargo.toml
+++ b/examples/http-request/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-reqwasm = "0.5.0"
+gloo-net = { version = "0.6.0", features = ["http"] }
 serde = "1.0.147"
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }

--- a/examples/http-request/Cargo.toml
+++ b/examples/http-request/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
-log = "0.4.17"
 reqwasm = "0.5.0"
 serde = "1.0.147"
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }

--- a/examples/http-request/src/main.rs
+++ b/examples/http-request/src/main.rs
@@ -1,4 +1,4 @@
-use reqwasm::http::Request;
+use gloo_net::http::Request;
 use serde::{Deserialize, Serialize};
 use sycamore::prelude::*;
 use sycamore::web::Suspense;
@@ -11,7 +11,7 @@ struct Visits {
     value: u64,
 }
 
-async fn fetch_visits(id: &str) -> Result<Visits, reqwasm::Error> {
+async fn fetch_visits(id: &str) -> Result<Visits, gloo_net::Error> {
     let url = format!("{API_BASE_URL}/{id}/http-request");
     let resp = Request::get(&url).send().await?;
 

--- a/examples/http-request/src/main.rs
+++ b/examples/http-request/src/main.rs
@@ -47,7 +47,5 @@ fn App() -> View {
 
 fn main() {
     console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Debug).unwrap();
-
     sycamore::render(App);
 }

--- a/examples/hydrate/Cargo.toml
+++ b/examples/hydrate/Cargo.toml
@@ -7,7 +7,5 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
-log = "0.4.17"
 sycamore = { path = "../../packages/sycamore", features = ["hydrate"] }
 wasm-bindgen = "0.2.83"

--- a/examples/hydrate/src/main.rs
+++ b/examples/hydrate/src/main.rs
@@ -63,7 +63,6 @@ fn App() -> View {
 fn main() {
     if is_not_ssr!() {
         console_error_panic_hook::set_once();
-        console_log::init_with_level(log::Level::Debug).unwrap();
         sycamore::hydrate(App);
     } else {
         // Create inedx.html from template.html and insert the rendered HTML.

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -7,8 +7,6 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
-log = "0.4.17"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"
 sycamore = { path = "../../packages/sycamore", features = ["serde"] }

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -111,8 +111,6 @@ const KEY: &str = "todos-sycamore";
 
 fn main() {
     console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Debug).unwrap();
-
     sycamore::render(App);
 }
 

--- a/examples/transitions/Cargo.toml
+++ b/examples/transitions/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
 getrandom = { version = "0.2.8", features = ["js"] }
 gloo-timers = { version = "0.2.4", features = ["futures"] }
-log = "0.4.17"
 rand = "0.8.5"
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }

--- a/examples/transitions/src/main.rs
+++ b/examples/transitions/src/main.rs
@@ -59,7 +59,5 @@ fn App() -> View {
 
 fn main() {
     console_error_panic_hook::set_once();
-    console_log::init_with_level(log::Level::Debug).unwrap();
-
     sycamore::render(App);
 }

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -7,9 +7,6 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-console_log = "0.2.0"
-js-sys = "0.3.60"
-log = "0.4.17"
 reqwasm = "0.5.0"
 serde-lite = { version = "0.3.2", features = ["derive"] }
 serde_json = "1.0.89"

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-reqwasm = "0.5.0"
+gloo-net = { version = "0.6.0", features = ["http"] }
 serde-lite = { version = "0.3.2", features = ["derive"] }
 serde_json = "1.0.89"
 sycamore = { path = "../packages/sycamore", features = ["suspense"] }

--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -8,11 +8,10 @@ edition = "2021"
 [dependencies]
 console_error_panic_hook = "0.1.7"
 gloo-net = { version = "0.6.0", features = ["http"] }
-serde-lite = { version = "0.3.2", features = ["derive"] }
+serde-lite = { version = "0.5.0", features = ["derive"] }
 serde_json = "1.0.89"
 sycamore = { path = "../packages/sycamore", features = ["suspense"] }
 sycamore-router = { path = "../packages/sycamore-router" }
-wasm-bindgen = "0.2.83"
 
 [dependencies.web-sys]
 features = ["CssStyleDeclaration", "MediaQueryList", "Storage", "Window"]

--- a/website/src/header.rs
+++ b/website/src/header.rs
@@ -1,5 +1,5 @@
 use sycamore::prelude::*;
-use wasm_bindgen::JsCast;
+use sycamore::web::wasm_bindgen::JsCast;
 use web_sys::HtmlElement;
 
 use crate::sidebar::{SidebarCurrent, SidebarData};

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -6,7 +6,7 @@ mod sidebar;
 mod versions;
 
 use content::MarkdownPage;
-use reqwasm::http::Request;
+use gloo_net::http::Request;
 use serde_lite::Deserialize;
 use sidebar::SidebarData;
 use sycamore::futures::{create_resource, spawn_local_scoped};

--- a/website/src/main.rs
+++ b/website/src/main.rs
@@ -207,10 +207,6 @@ fn App() -> View {
 
 fn main() {
     #[cfg(debug_assertions)]
-    {
-        console_error_panic_hook::set_once();
-        console_log::init_with_level(log::Level::Debug).unwrap();
-    }
-
+    console_error_panic_hook::set_once();
     sycamore::render(App);
 }


### PR DESCRIPTION
Removes usage of `log`, `console_log`, and some other dependencies from examples that are no longer needed.