### PR TITLE
Fix #704 - Updating the check whether a view must be dynamic.

### DIFF
--- a/examples/attributes-passthrough/src/main.rs
+++ b/examples/attributes-passthrough/src/main.rs
@@ -18,7 +18,6 @@ fn CustomButton(props: CustomButtonProps) -> View {
 
     let children = props.children.call();
     view! {
-        // TODO: Remove the .clone() here.
         button(id=props.id, ..props.attributes) {
             (children)
         }

--- a/examples/attributes-passthrough/src/main.rs
+++ b/examples/attributes-passthrough/src/main.rs
@@ -19,7 +19,7 @@ fn CustomButton(props: CustomButtonProps) -> View {
     let children = props.children.call();
     view! {
         // TODO: Remove the .clone() here.
-        button(id=props.id.clone(), ..props.attributes) {
+        button(id=props.id, ..props.attributes) {
             (children)
         }
     }


### PR DESCRIPTION
Fix for #704.

The following expressions will be considered as non-dynamic (NDY):

- literal
- closure
- path
- field accessor
```rust
document.author.id
```
- parentheses, where inner expression is NDY
```rust
(expr)
```
- tuple, where elements are NDY
```rust
(a, b, c)
```
- array, where elements or length are NDY
```rust
[a, b, c]
[d; len]
```
- struct, where field values are NDY
```rust
Doc {
    id: a,
    author: Author {
        id: (b, c),
    },
}
```
- type cast, where expression is NDY
```rust
expr as sometype
```
- **view!** macro
- block, when either a const block, or all statements are NDY
- **loop**, **while** and **for**, (when all their parts are NDY)
- **break**, **continue**
- **let**, when pattern and expression are NDY
- **match**, when the matched expression, and all arms (patterns, guards and bodies) are NDY
- **if**, when the condition and branches are NDY
- unary,binary, index and range expressions, when composed from NDY

Everything else is still considered dynamic.