### PR TITLE
Allow optional attribute values

### DIFF
--- a/packages/sycamore-reactive/src/maybe_dyn.rs
+++ b/packages/sycamore-reactive/src/maybe_dyn.rs
@@ -186,6 +186,12 @@ impl<T> From<Vec<T>> for MaybeDyn<Vec<T>> {
     }
 }
 
+impl<T: Into<U>, U> From<Option<T>> for MaybeDyn<Option<U>> {
+    fn from(opt: Option<T>) -> Self {
+        MaybeDyn::Static(opt.map(|x| x.into()))
+    }
+}
+
 #[cfg(feature = "wasm-bindgen")]
 impl_into_maybe_dyn!(
     wasm_bindgen::JsValue;

--- a/packages/sycamore-view-parser/src/ir.rs
+++ b/packages/sycamore-view-parser/src/ir.rs
@@ -49,12 +49,12 @@ pub struct Prop {
 }
 
 pub enum PropType {
-    /// Syntax: `<name>=<expr>`.
-    Plain { ident: Ident },
-    /// Syntax: `<hyphenated-name>=<expr>`.
-    PlainHyphenated { ident: String },
-    /// Syntax: `"<quoted-name>"=<expr>`.
-    PlainQuoted { ident: String },
+    /// Syntax: `<name>=<expr>` or `<name>?=<optional_expr>`.
+    Plain { ident: Ident, optional: bool },
+    /// Syntax: `<hyphenated-name>=<expr> or `<hyphenated-name>?=<optional_expr>`.
+    PlainHyphenated { ident: String, optional: bool },
+    /// Syntax: `"<quoted-name>"=<expr>` or `"<quoted-name>"?=<optional_expr>`.
+    PlainQuoted { ident: String, optional: bool },
     /// Syntax: `<dir>:<prop>=<expr>`.
     Directive { dir: Ident, ident: Ident },
     /// Syntax: `ref=<expr>`.

--- a/packages/sycamore-web/src/attributes.rs
+++ b/packages/sycamore-web/src/attributes.rs
@@ -13,6 +13,12 @@ impl AttributeValue for MaybeDyn<Cow<'static, str>> {
     }
 }
 
+impl AttributeValue for MaybeDyn<Option<Cow<'static, str>>> {
+    fn set_self(self, el: &mut HtmlNode, name: Cow<'static, str>) {
+        el.set_attribute_option(name, self);
+    }
+}
+
 impl AttributeValue for MaybeDyn<bool> {
     fn set_self(self, el: &mut HtmlNode, name: Cow<'static, str>) {
         el.set_bool_attribute(name, self);

--- a/packages/sycamore-web/src/elements.rs
+++ b/packages/sycamore-web/src/elements.rs
@@ -1118,6 +1118,16 @@ pub trait GlobalAttributes: SetAttribute + Sized {
         self
     }
 
+    /// Set attribute `name` with `value` from Option.
+    fn attr_opt(
+        mut self,
+        name: &'static str,
+        value: impl Into<MaybeDyn<Option<Cow<'static, str>>>>,
+    ) -> Self {
+        self.set_attribute(name, value.into());
+        self
+    }
+
     /// Set attribute `name` with `value`.
     fn bool_attr(mut self, name: &'static str, value: impl Into<MaybeDyn<bool>>) -> Self {
         self.set_attribute(name, value.into());

--- a/packages/sycamore-web/src/node/dom_node.rs
+++ b/packages/sycamore-web/src/node/dom_node.rs
@@ -131,6 +131,31 @@ impl ViewHtmlNode for DomNode {
         }
     }
 
+    fn set_attribute_option(
+        &mut self,
+        name: Cow<'static, str>,
+        value: MaybeDyn<Option<Cow<'static, str>>>,
+    ) {
+        // FIXME: use setAttributeNS if SVG
+        if let Some(value) = value.as_static() {
+            if let Some(value) = value {
+                self.raw
+                    .unchecked_ref::<web_sys::Element>()
+                    .set_attribute(&name, value)
+                    .unwrap();
+            }
+        } else {
+            let node = self.raw.clone().unchecked_into::<web_sys::Element>();
+            create_effect(move || {
+                if let Some(value) = value.get_clone() {
+                    node.set_attribute(&name, &value).unwrap();
+                } else {
+                    node.remove_attribute(&name);
+                }
+            });
+        }
+    }
+
     fn set_bool_attribute(&mut self, name: Cow<'static, str>, value: MaybeDyn<bool>) {
         // FIXME: use setAttributeNS if SVG
         if let Some(value) = value.as_static() {

--- a/packages/sycamore-web/src/node/mod.rs
+++ b/packages/sycamore-web/src/node/mod.rs
@@ -51,6 +51,12 @@ pub trait ViewHtmlNode: ViewNode {
 
     /// Set an HTML attribute.
     fn set_attribute(&mut self, name: Cow<'static, str>, value: MaybeDyn<Cow<'static, str>>);
+    /// Set an HTML attribute, if the value is Some(x), otherwise remove the attribute.
+    fn set_attribute_option(
+        &mut self,
+        name: Cow<'static, str>,
+        value: MaybeDyn<Option<Cow<'static, str>>>,
+    );
     /// Set a boolean HTML attribute.
     fn set_bool_attribute(&mut self, name: Cow<'static, str>, value: MaybeDyn<bool>);
     /// Set a JS property on an element.

--- a/packages/sycamore-web/src/node/ssr_node.rs
+++ b/packages/sycamore-web/src/node/ssr_node.rs
@@ -115,6 +115,21 @@ impl ViewHtmlNode for SsrNode {
         }
     }
 
+    fn set_attribute_option(
+        &mut self,
+        name: Cow<'static, str>,
+        value: MaybeDyn<Option<Cow<'static, str>>>,
+    ) {
+        match self {
+            Self::Element { attributes, .. } => {
+                if let Some(value) = value.evaluate() {
+                    attributes.push((name, value))
+                }
+            }
+            _ => panic!("can only set attribute on an element"),
+        }
+    }
+
     fn set_bool_attribute(&mut self, name: Cow<'static, str>, value: MaybeDyn<bool>) {
         match self {
             Self::Element {
@@ -345,7 +360,9 @@ mod tests {
                     }
                 }
             },
-            expect![[r#"<svg xmlns="http://www.w2.org/2000/svg" data-hk="0.0"><rect data-hk="0.1"></rect></svg>"#]],
+            expect![[
+                r#"<svg xmlns="http://www.w2.org/2000/svg" data-hk="0.0"><rect data-hk="0.1"></rect></svg>"#
+            ]],
         );
         check(
             move || {


### PR DESCRIPTION
- Added .attr_opt() method into builder-like API.

- Allow optional attributes in view! macro, the syntax is: 
  `<attr-name>?=<optional_value>`

- If the attribute value is None, the attribute is removed, just like a bool attribute does with a `false` value.

This should fix #622 (and maybe #447?)

Example:

```rust
fn main() {
    sycamore::render(|| {
        type SigOptStr<'a> = ReadSignal<Option<Cow<'a, str>>>;

        let the_class = Some("extra-dark");
        let sig_counter: Signal<i32> = create_signal(0);

        let on_btn_click = move |_| {
            sig_counter.set(sig_counter.get() + 1);
        };

        let sig_style: SigOptStr = sig_counter.map(|i| {
            if i % 2 == 1 {
                Some("color: red;".into())
            } else {
                None
            }
        });

        let sig_main_id: SigOptStr = sig_counter.map(|i| {
            if i % 2 == 0 {
                Some(i.to_string().into())
            } else {
                None
            }
        });

        let sig_data_id: SigOptStr = sig_counter.map(|i| {
            if i % 3 == 0 {
                Some(i.to_string().into())
            } else {
                None
            }
        });

        view! {
            button(on:click=on_btn_click) { "Toggle" }
            p(
                // Quoted attribute, dynamic non-option value
                "counter"=sig_counter.to_string(),
                // Plain attribute, non-dynamic option value
                class?=the_class,
                // Plain attribute, dynamic option value
                id?=sig_main_id,
                // Dashed attribute, dynamic option value
                data-id?=sig_data_id,
                // Quoted attribute, dynamic option value
                "style"?=sig_style,
            ) {
                "Some text"
            }
        }
    });
}
```

If this approach is acceptable - let me know, I'll add some tests into sycamore-macro (but if some other tests would be needed - let me know where).