### PR TITLE
Support `MaybeDyn<Option<Cow<'static, str>>>` and make some impls more flexible

### DIFF
--- a/packages/sycamore-reactive/src/maybe_dyn.rs
+++ b/packages/sycamore-reactive/src/maybe_dyn.rs
@@ -156,6 +156,18 @@ macro_rules! impl_into_maybe_dyn {
                         MaybeDyn::Static(val.into())
                     }
                 }
+
+                impl From<$crate::ReadSignal<$from>> for $crate::MaybeDyn<$ty> {
+                    fn from(val: $crate::ReadSignal<$from>) -> Self {
+                        MaybeDyn::Derived(Rc::new(move || val.get_clone().into()))
+                    }
+                }
+
+                impl From<$crate::Signal<$from>> for $crate::MaybeDyn<$ty> {
+                    fn from(val: $crate::Signal<$from>) -> Self {
+                        (*val).into()
+                    }
+                }
             )*
         )?
     };
@@ -179,6 +191,12 @@ impl_into_maybe_dyn!(u32);
 impl_into_maybe_dyn!(u64);
 impl_into_maybe_dyn!(u128);
 impl_into_maybe_dyn!(usize);
+
+impl<T> From<Option<T>> for MaybeDyn<Option<T>> {
+    fn from(val: Option<T>) -> Self {
+        MaybeDyn::Static(val)
+    }
+}
 
 impl<T> From<Vec<T>> for MaybeDyn<Vec<T>> {
     fn from(val: Vec<T>) -> Self {
@@ -209,7 +227,7 @@ mod tests {
     fn maybe_dyn_signal() {
         let _ = create_root(move || {
             let signal = create_signal(123);
-            let value = MaybeDyn::from(signal);
+            let value = MaybeDyn::<i32>::from(signal);
             assert!(value.as_static().is_none());
             assert_eq!(value.get(), 123);
             assert_eq!(value.get_clone(), 123);

--- a/packages/sycamore/tests/web/cleanup.rs
+++ b/packages/sycamore/tests/web/cleanup.rs
@@ -2,7 +2,7 @@ use std::cell::Cell;
 
 use super::*;
 
-thread_local!(static CLEANUP_CALLED: Cell<bool> = Cell::new(false));
+thread_local!(static CLEANUP_CALLED: Cell<bool> = const { Cell::new(false) });
 fn assert_cleanup_called(f: impl FnOnce()) {
     CLEANUP_CALLED.with(|cleanup_called| {
         cleanup_called.set(false);

--- a/packages/sycamore/tests/web/indexed.rs
+++ b/packages/sycamore/tests/web/indexed.rs
@@ -231,7 +231,12 @@ fn insert_front() {
 #[wasm_bindgen_test]
 fn nested_reactivity() {
     let _ = create_root(|| {
-        let count = create_signal(vec![1, 2, 3].into_iter().map(create_signal).collect());
+        let count = create_signal(
+            vec![1, 2, 3]
+                .into_iter()
+                .map(create_signal)
+                .collect::<Vec<_>>(),
+        );
 
         let view = move || {
             view! {

--- a/packages/sycamore/tests/web/keyed.rs
+++ b/packages/sycamore/tests/web/keyed.rs
@@ -271,7 +271,12 @@ fn insert_front() {
 #[wasm_bindgen_test]
 fn nested_reactivity() {
     let _ = create_root(|| {
-        let count = create_signal(vec![1, 2, 3].into_iter().map(create_signal).collect());
+        let count = create_signal(
+            vec![1, 2, 3]
+                .into_iter()
+                .map(create_signal)
+                .collect::<Vec<_>>(),
+        );
 
         let view = move || {
             view! {

--- a/packages/tools/bench/benches/reactivity.rs
+++ b/packages/tools/bench/benches/reactivity.rs
@@ -43,7 +43,7 @@ pub fn bench(c: &mut Criterion) {
     c.bench_function("reactivity_map_indexed", |b| {
         let root = create_root(|| {
             b.iter(|| {
-                let v = create_signal((0..100).collect());
+                let v = create_signal((0..100).collect::<Vec<_>>());
                 let mapped = map_indexed(v, |x| x * 2);
                 mapped.track();
 
@@ -57,7 +57,7 @@ pub fn bench(c: &mut Criterion) {
     c.bench_function("reactivity_map_keyed", |b| {
         let root = create_root(|| {
             b.iter(|| {
-                let v = create_signal((0..100).collect());
+                let v = create_signal((0..100).collect::<Vec<_>>());
                 let mapped = map_keyed(v, |x| x * 2, |x| *x);
                 mapped.track();
 


### PR DESCRIPTION
This lays the foundation for supporting optional attributes in #622.

This is technically a breaking change because of some obscure type-inference changes. However, this should affect almost nobody.