### PR TITLE
Disable website publishing workflow

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -1,8 +1,6 @@
 name: Build website
 
-on:
-  push:
-    branches: [main]
+on: []
 
 jobs:
   deploy:


### PR DESCRIPTION
This is to prepare for moving to the new docsite which will be built in a new repo.