### PR TITLE
Make `SsrNode` automatically create reactive nodes by default

### DIFF
--- a/packages/sycamore-web/src/node/dom_node.rs
+++ b/packages/sycamore-web/src/node/dom_node.rs
@@ -35,10 +35,9 @@ pub(crate) fn _create_dynamic_view<T: ViewHtmlNode, U: Into<View<T>> + 'static>(
     // effect to update its text value without ever creating more nodes.
     if TypeId::of::<U>() == TypeId::of::<String>() {
         create_effect_initial(move || {
-            let text = (Box::new(f()) as Box<dyn Any>)
-                .downcast::<String>()
-                .unwrap();
-            let view = View::from_node(T::create_dynamic_text_node((*text).into()));
+            let text: &mut Option<String> =
+                (&mut Some(f()) as &mut dyn Any).downcast_mut().unwrap();
+            let view = View::from_node(T::create_dynamic_text_node(text.take().unwrap().into()));
             debug_assert_eq!(
                 view.nodes.len(),
                 1,

--- a/packages/sycamore-web/src/node/dom_node.rs
+++ b/packages/sycamore-web/src/node/dom_node.rs
@@ -35,8 +35,8 @@ pub(crate) fn _create_dynamic_view<T: ViewHtmlNode, U: Into<View<T>> + 'static>(
     // effect to update its text value without ever creating more nodes.
     if TypeId::of::<U>() == TypeId::of::<String>() {
         create_effect_initial(move || {
-            let text: &mut Option<String> =
-                (&mut Some(f()) as &mut dyn Any).downcast_mut().unwrap();
+            let mut value = Some(f());
+            let text: &mut Option<String> = (&mut value as &mut dyn Any).downcast_mut().unwrap();
             let view = View::from_node(T::create_dynamic_text_node(text.take().unwrap().into()));
             debug_assert_eq!(
                 view.nodes.len(),


### PR DESCRIPTION
Previous behavior: dynamic nodes created on the server were not actually dynamic, i.e. the values would not update even when signals are updated.

New behavior: dynamic nodes are always dynamic. This solves a bunch of inconsistencies and makes it easier to use resources which update the value dynamically.