### PR TITLE
Do not track callback in `on` function callback

### DIFF
--- a/packages/sycamore-reactive/src/utils.rs
+++ b/packages/sycamore-reactive/src/utils.rs
@@ -53,12 +53,13 @@ impl_trackable_deps_for_tuple!(A, B, C, D, E, F, G, H, I, J);
 impl_trackable_deps_for_tuple!(A, B, C, D, E, F, G, H, I, J, K);
 impl_trackable_deps_for_tuple!(A, B, C, D, E, F, G, H, I, J, K, L);
 
-/// A helper function for making dependencies explicit.
+/// A helper function for making dependencies explicit. This will create a closure that tracks
+/// those and only those dependencies that are passed to it.
 ///
 /// # Params
 /// * `deps` - A list of signals/memos that are tracked. This can be a single signal or it can be a
 ///   tuple of signals.
-/// * `f` - The callback function.
+/// * `f` - The callback function. Any dependencies that are accessed in here will not be tracked.
 ///
 /// # Example
 /// ```


### PR DESCRIPTION
Previous behavior tracked dependencies in both dependency list and in callback.

The expected behavior is probably that it only tracks the dependencies specified explicitly in the dependency list. This PR updates the `on` function to this behavior. Also adds a test to prevent regressions.