### PR TITLE
Forward attributes on function parameters to generated prop struct in `inline_props`

### DIFF
--- a/packages/sycamore-macro/src/component.rs
+++ b/packages/sycamore-macro/src/component.rs
@@ -280,19 +280,18 @@ fn inline_props_impl(item: &mut ItemFn, attrs: Punctuated<Meta, Token![,]>) -> R
     let props = inputs.clone().into_iter().collect::<Vec<_>>();
     let generics: &mut Generics = &mut item.sig.generics;
     let mut fields = Vec::new();
-    inputs.iter().for_each(|arg| match arg {
+    inputs.into_iter().for_each(|arg| match arg {
         FnArg::Receiver(_) => {
             unreachable!("receiver cannot be a prop")
         }
         FnArg::Typed(pat_type) => {
-            let pat = &*pat_type.pat;
-            let ty = &*pat_type.ty;
-            match pat {
+            match *pat_type.pat {
                 Pat::Ident(ident_pat) => super::inline_props::push_field(
                     &mut fields,
                     generics,
+                    pat_type.attrs,
                     ident_pat.clone().ident,
-                    ty.clone(),
+                    *pat_type.ty,
                 ),
                 _ => {
                     unreachable!("unexpected pattern!")

--- a/packages/sycamore-macro/src/component.rs
+++ b/packages/sycamore-macro/src/component.rs
@@ -284,20 +284,18 @@ fn inline_props_impl(item: &mut ItemFn, attrs: Punctuated<Meta, Token![,]>) -> R
         FnArg::Receiver(_) => {
             unreachable!("receiver cannot be a prop")
         }
-        FnArg::Typed(pat_type) => {
-            match *pat_type.pat {
-                Pat::Ident(ident_pat) => super::inline_props::push_field(
-                    &mut fields,
-                    generics,
-                    pat_type.attrs,
-                    ident_pat.clone().ident,
-                    *pat_type.ty,
-                ),
-                _ => {
-                    unreachable!("unexpected pattern!")
-                }
+        FnArg::Typed(pat_type) => match *pat_type.pat {
+            Pat::Ident(ident_pat) => super::inline_props::push_field(
+                &mut fields,
+                generics,
+                pat_type.attrs,
+                ident_pat.clone().ident,
+                *pat_type.ty,
+            ),
+            _ => {
+                unreachable!("unexpected pattern!")
             }
-        }
+        },
     });
 
     let generics_phantoms = generics.params.iter().enumerate().filter_map(|(i, param)| {

--- a/packages/sycamore-macro/src/inline_props.rs
+++ b/packages/sycamore-macro/src/inline_props.rs
@@ -2,8 +2,7 @@ use proc_macro2::Span;
 use quote::format_ident;
 use syn::punctuated::Punctuated;
 use syn::{
-    Field, GenericParam, Generics, Ident, Path, PathArguments, PathSegment, Token, Type,
-    TypeImplTrait, TypeParam, TypePath, Visibility,
+    Attribute, Field, GenericParam, Generics, Ident, Path, PathArguments, PathSegment, Token, Type, TypeImplTrait, TypeParam, TypePath, Visibility
 };
 
 pub fn create_generic_ident(generics: &Generics) -> Ident {
@@ -85,7 +84,7 @@ pub fn add_generic(generics: &mut Generics, impl_type: TypeImplTrait) -> Type {
     })
 }
 
-pub fn push_field(fields: &mut Vec<Field>, generics: &mut Generics, attrs: Vec<Attributes>, ident: Ident, ty: Type) {
+pub fn push_field(fields: &mut Vec<Field>, generics: &mut Generics, attrs: Vec<Attribute>, ident: Ident, ty: Type) {
     let ty = resolve_type(generics, ty);
 
     fields.push(Field {

--- a/packages/sycamore-macro/src/inline_props.rs
+++ b/packages/sycamore-macro/src/inline_props.rs
@@ -85,11 +85,11 @@ pub fn add_generic(generics: &mut Generics, impl_type: TypeImplTrait) -> Type {
     })
 }
 
-pub fn push_field(fields: &mut Vec<Field>, generics: &mut Generics, ident: Ident, ty: Type) {
+pub fn push_field(fields: &mut Vec<Field>, generics: &mut Generics, attrs: Vec<Attributes>, ident: Ident, ty: Type) {
     let ty = resolve_type(generics, ty);
 
     fields.push(Field {
-        attrs: Vec::new(),
+        attrs,
         vis: Visibility::Public(Token![pub](Span::call_site())),
         mutability: syn::FieldMutability::None,
         ident: Some(ident),

--- a/packages/sycamore-macro/src/inline_props.rs
+++ b/packages/sycamore-macro/src/inline_props.rs
@@ -2,7 +2,8 @@ use proc_macro2::Span;
 use quote::format_ident;
 use syn::punctuated::Punctuated;
 use syn::{
-    Attribute, Field, GenericParam, Generics, Ident, Path, PathArguments, PathSegment, Token, Type, TypeImplTrait, TypeParam, TypePath, Visibility
+    Attribute, Field, GenericParam, Generics, Ident, Path, PathArguments, PathSegment, Token, Type,
+    TypeImplTrait, TypeParam, TypePath, Visibility,
 };
 
 pub fn create_generic_ident(generics: &Generics) -> Ident {
@@ -84,7 +85,13 @@ pub fn add_generic(generics: &mut Generics, impl_type: TypeImplTrait) -> Type {
     })
 }
 
-pub fn push_field(fields: &mut Vec<Field>, generics: &mut Generics, attrs: Vec<Attribute>, ident: Ident, ty: Type) {
+pub fn push_field(
+    fields: &mut Vec<Field>,
+    generics: &mut Generics,
+    attrs: Vec<Attribute>,
+    ident: Ident,
+    ty: Type,
+) {
     let ty = resolve_type(generics, ty);
 
     fields.push(Field {

--- a/packages/sycamore-macro/tests/component/inline-props-pass.rs
+++ b/packages/sycamore-macro/tests/component/inline-props-pass.rs
@@ -84,4 +84,19 @@ fn AdditionalStructAttributes(dummy: String) -> View {
     }
 }
 
+#[component(inline_props)]
+fn PropsWithAttributes(
+    #[prop(default)]
+    dummy: String,
+) -> View {
+    fn call_component() -> View {
+        view! {
+            PropsWithAttributes {}
+        }
+    }
+    view! {
+        (dummy)
+    }
+}
+
 fn main() {}


### PR DESCRIPTION
Fixes a regression from `0.9.0-beta.4` where function arguments no longer forward their attributes to the generated prop struct when using `inline_props`.

For example, this should forward the attributes onto the corresponding field in the props struct.
```rust
#[component(inline_props)]
fn Foo(
    /// Test
    #[prop(default)]
    value: i32,
) -> View { ... }
```
