### PR TITLE
Move view.rs from sycamore-macro into sycamore-view-parser codegen.rs

### DIFF
--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -10,7 +10,6 @@ use syn::{parse_macro_input, DeriveInput};
 mod component;
 mod inline_props;
 mod props;
-mod view;
 
 /// A macro for ergonomically creating complex UI complex layouts.
 ///
@@ -20,7 +19,7 @@ mod view;
 pub fn view(input: TokenStream) -> TokenStream {
     let root = parse_macro_input!(input as sycamore_view_parser::ir::Root);
 
-    view::Codegen {}.root(&root).into()
+    sycamore_view_parser::codegen::Codegen {}.root(&root).into()
 }
 
 /// A macro for creating components from functions.

--- a/packages/sycamore-view-parser/src/codegen.rs
+++ b/packages/sycamore-view-parser/src/codegen.rs
@@ -5,8 +5,9 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use sycamore_view_parser::ir::{DynNode, Node, Prop, PropType, Root, TagIdent, TagNode, TextNode};
 use syn::{Expr, Pat};
+
+use crate::ir::{DynNode, Node, Prop, PropType, Root, TagIdent, TagNode, TextNode};
 
 pub struct Codegen {
     // TODO: configure mode: Client, Hydrate, SSR

--- a/packages/sycamore-view-parser/src/lib.rs
+++ b/packages/sycamore-view-parser/src/lib.rs
@@ -1,4 +1,5 @@
 //! Proc-macro support crate for Sycamore.
 
+pub mod codegen;
 pub mod ir;
 pub mod parse;


### PR DESCRIPTION
This would greatly simplify making 3rd party alternative view macros #23 only having to make the common ir rather then a custom solution that would work basically identically to the existing codegen solution.
Right now the view.rs was not accessible by other crates because the crate it is in is a proc-macro crate.
I know that technically the crate is named sycamore-view-**parser** and codegen isn't parsing but making a separate crate would be redundant in my opinion since the ir is also needed together with the codegen and i don't think its worth it renaming the crate since its already on crates.io.

Unrelated side note: I am working on and off on Fallible components trying to make it good. I just need a short change (e.g. making sycamore-rstml)