### PR TITLE
owned String required .into() or .to_string()

### DIFF
--- a/docs/next/introduction/your-first-app.md
+++ b/docs/next/introduction/your-first-app.md
@@ -275,7 +275,7 @@ Sycamore!".
 
 ```rust
 view! {
-    Hello(name="Sycamore")
+    Hello(name="Sycamore".into())
 }
 ```
 


### PR DESCRIPTION
Compiler was complaining about this. Apparently we need .into() or .to_string(). Feel free to change this to whatever is preferred.

In a previous Sycamore version, was this not required?