### PR TITLE
Fix `unexpected_cfgs` in the crates and add a troubleshooting note

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,4 +60,4 @@ sycamore-web = { path = "packages/sycamore-web", version = "0.9.1" }
 debug = true
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(sycamore_force_ssr)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(sycamore_force_ssr)", "cfg(rust_analyzer)"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,6 @@ sycamore-web = { path = "packages/sycamore-web", version = "0.9.1" }
 
 [profile.bench]
 debug = true
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(sycamore_force_ssr)'] }

--- a/docs/next/troubleshooting.md
+++ b/docs/next/troubleshooting.md
@@ -18,3 +18,18 @@ console_error_panic_hook::set_once();
 ## Debugging using DWARF + WASM
 
 > Note: This section is a stub. Help us write this section!
+
+## unexpected `cfg` condition name: `sycamore_force_ssr`
+
+Sycamore uses a custom cfg (`sycamore_force_ssr`) to force the SSR mode. Because
+the compiler doesn't know about custom cfg it will emit warnings. To disables
+those warnings, add the following lints configuration in the `Cargo.toml` file
+of your project.
+
+```toml
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(sycamore_force_ssr)"] }
+```
+
+More information here:
+<https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#check-cfg-in-lintsrust-table>

--- a/examples/attributes-passthrough/Cargo.toml
+++ b/examples/attributes-passthrough/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/components/Cargo.toml
+++ b/examples/components/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/context/Cargo.toml
+++ b/examples/context/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/hello-builder/Cargo.toml
+++ b/examples/hello-builder/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 [dependencies]
 console_error_panic_hook = "0.1.7"
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/higher-order-components/Cargo.toml
+++ b/examples/higher-order-components/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/http-request-builder/Cargo.toml
+++ b/examples/http-request-builder/Cargo.toml
@@ -10,3 +10,7 @@ console_error_panic_hook = "0.1.7"
 gloo-net = { version = "0.6.0", features = ["http"] }
 serde = { version = "1.0.147", features = ["derive"] }
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }
+
+
+[lints]
+workspace = true

--- a/examples/http-request/Cargo.toml
+++ b/examples/http-request/Cargo.toml
@@ -10,3 +10,7 @@ console_error_panic_hook = "0.1.7"
 gloo-net = { version = "0.6.0", features = ["http"] }
 serde = { version = "1.0.147", features = ["derive"] }
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }
+
+
+[lints]
+workspace = true

--- a/examples/hydrate/Cargo.toml
+++ b/examples/hydrate/Cargo.toml
@@ -9,3 +9,6 @@ edition = "2021"
 console_error_panic_hook = "0.1.7"
 sycamore = { path = "../../packages/sycamore", features = ["hydrate"] }
 wasm-bindgen = "0.2.83"
+
+[lints]
+workspace = true

--- a/examples/iteration/Cargo.toml
+++ b/examples/iteration/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/js-framework-benchmark/Cargo.toml
+++ b/examples/js-framework-benchmark/Cargo.toml
@@ -10,3 +10,7 @@ console_error_panic_hook = "0.1.7"
 getrandom = { version = "0.2.8", features = ["js"] }
 rand = "0.8.5"
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/js-snippets/Cargo.toml
+++ b/examples/js-snippets/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
 wasm-bindgen = "0.2.83"
+
+
+[lints]
+workspace = true

--- a/examples/motion/Cargo.toml
+++ b/examples/motion/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 [dependencies]
 console_error_panic_hook = "0.1.7"
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/number-binding/Cargo.toml
+++ b/examples/number-binding/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
 sycamore-router = { path = "../../packages/sycamore-router" }
+
+
+[lints]
+workspace = true

--- a/examples/ssr-streaming/Cargo.toml
+++ b/examples/ssr-streaming/Cargo.toml
@@ -9,6 +9,9 @@ sycamore = { path = "../../packages/sycamore", features = [
 	"hydrate",
 ] }
 
+[lints]
+workspace = true
+
 [target.'cfg(all(target_arch = "wasm32", not(sycamore_force_ssr)))'.dependencies]
 console_error_panic_hook = "0.1.7"
 

--- a/examples/ssr-suspense/Cargo.toml
+++ b/examples/ssr-suspense/Cargo.toml
@@ -9,6 +9,9 @@ sycamore = { path = "../../packages/sycamore", features = [
 	"hydrate",
 ] }
 
+[lints]
+workspace = true
+
 [target.'cfg(all(target_arch = "wasm32", not(sycamore_force_ssr)))'.dependencies]
 console_error_panic_hook = "0.1.7"
 

--- a/examples/ssr/Cargo.toml
+++ b/examples/ssr/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/svg/Cargo.toml
+++ b/examples/svg/Cargo.toml
@@ -7,3 +7,7 @@ edition = "2021"
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
+
+
+[lints]
+workspace = true

--- a/examples/timer/Cargo.toml
+++ b/examples/timer/Cargo.toml
@@ -8,3 +8,7 @@ edition = "2021"
 [dependencies]
 gloo-timers = { version = "0.2.4", features = ["futures"] }
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }
+
+
+[lints]
+workspace = true

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -15,3 +15,7 @@ uuid = { version = "1.2.2", features = ["serde", "v4", "js"] }
 [dependencies.web-sys]
 features = ["Location", "Storage", "HtmlInputElement"]
 version = "0.3.60"
+
+
+[lints]
+workspace = true

--- a/examples/transitions/Cargo.toml
+++ b/examples/transitions/Cargo.toml
@@ -11,3 +11,7 @@ getrandom = { version = "0.2.8", features = ["js"] }
 gloo-timers = { version = "0.2.4", features = ["futures"] }
 rand = "0.8.5"
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }
+
+
+[lints]
+workspace = true

--- a/packages/sycamore-core/Cargo.toml
+++ b/packages/sycamore-core/Cargo.toml
@@ -22,3 +22,7 @@ sycamore = { path = "../sycamore" }
 [features]
 default = []
 suspense = ["sycamore-futures"]
+
+
+[lints]
+workspace = true

--- a/packages/sycamore-futures/Cargo.toml
+++ b/packages/sycamore-futures/Cargo.toml
@@ -26,5 +26,5 @@ tokio = { version = "1.22.0", features = ["rt"] }
 tokio = { version = "1.22.0", features = ["rt", "macros"] }
 tokio-test = "0.4.4"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(sycamore_force_ssr)'] }
+[lints]
+workspace = true

--- a/packages/sycamore-macro/Cargo.toml
+++ b/packages/sycamore-macro/Cargo.toml
@@ -27,3 +27,7 @@ trybuild = "1.0.71"
 
 [features]
 default = []
+
+
+[lints]
+workspace = true

--- a/packages/sycamore-reactive/Cargo.toml
+++ b/packages/sycamore-reactive/Cargo.toml
@@ -24,3 +24,7 @@ default = []
 nightly = []
 serde = ["dep:serde"]
 wasm-bindgen = ["dep:wasm-bindgen"]
+
+
+[lints]
+workspace = true

--- a/packages/sycamore-router-macro/Cargo.toml
+++ b/packages/sycamore-router-macro/Cargo.toml
@@ -24,3 +24,7 @@ syn = "2.0.10"
 expect-test = "1.4.0"
 sycamore-router = { path = "../sycamore-router" }
 trybuild = "1.0.71"
+
+
+[lints]
+workspace = true

--- a/packages/sycamore-router/Cargo.toml
+++ b/packages/sycamore-router/Cargo.toml
@@ -32,3 +32,7 @@ features = [
 	"UrlSearchParams",
 ]
 version = "0.3.60"
+
+
+[lints]
+workspace = true

--- a/packages/sycamore-view-parser/Cargo.toml
+++ b/packages/sycamore-view-parser/Cargo.toml
@@ -14,3 +14,7 @@ version.workspace = true
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
 syn = { version = "2.0.10", features = ["extra-traits", "full"] }
+
+
+[lints]
+workspace = true

--- a/packages/sycamore-web/Cargo.toml
+++ b/packages/sycamore-web/Cargo.toml
@@ -82,8 +82,6 @@ hydrate = []
 suspense = ["dep:sycamore-futures", "dep:futures", "dep:async-stream"]
 wasm-bindgen-interning = ["wasm-bindgen/enable-interning"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [
-	"cfg(sycamore_force_ssr)",
-	"cfg(rust_analyzer)",
-] }
+
+[lints]
+workspace = true

--- a/packages/sycamore/Cargo.toml
+++ b/packages/sycamore/Cargo.toml
@@ -56,3 +56,7 @@ required-features = ["hydrate"]
 [package.metadata.docs.rs]
 all-features = true
 default-target = "wasm32-unknown-unknown"
+
+
+[lints]
+workspace = true


### PR DESCRIPTION
- Moves the `unexpected_cfgs` lint configration at the workspace level
- Inherits the workspace lints in all crates
- Add a notes about the "unexpected `cfg` condition name: `sycamore_force_ssr`" in the troubleshooting section of the docs.