### PR TITLE
Fix missing deref in adding-state.md example

### DIFF
--- a/docs/next/introduction/adding-state.md
+++ b/docs/next/introduction/adding-state.md
@@ -295,7 +295,7 @@ fn CounterDisplay(value: ReadSignal<i32>) -> View {
 let counter = create_signal(1);
 
 view! {
-    CounterDisplay(value=counter)
+    CounterDisplay(value=*counter)
 }
 ```
 


### PR DESCRIPTION
I was referring to this part of the docs multiple times and each time I was puzzled, should I de-reference here or not.

Rust says I should.

Hope this will solve a confusion for future users.