### PR TITLE
Fix bug where the stop function in `create_raf_loop` was not actually being called

### DIFF
--- a/packages/sycamore/src/motion.rs
+++ b/packages/sycamore/src/motion.rs
@@ -76,12 +76,12 @@ pub fn create_raf(mut cb: impl FnMut() + 'static) -> RafState {
 ///
 /// The raf is not started by default. Call the `start` function to initiate the raf.
 pub fn create_raf_loop(mut f: impl FnMut() -> bool + 'static) -> RafState {
-    let stop_shared = Rc::new(OnceCell::new());
+    let stop_shared = Rc::new(OnceCell::<Rc<dyn Fn()>>::new());
     let (running, start, stop) = create_raf({
         let stop_shared = Rc::clone(&stop_shared);
         move || {
             if !f() {
-                stop_shared.get();
+                stop_shared.get().unwrap()();
             }
         }
     });


### PR DESCRIPTION
We were simply accessing the callback but not actually calling it. Silly me!

Fixes #790 