### PR TITLE
Enforce minimum supported Rust version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,3 +134,40 @@ jobs:
       - name: Run tests with all features
         run: |
           cargo miri test --all-features
+
+  msrv:
+    name: Build on below-minimum Rust version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.80.0
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        id: setup-rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+
+      - name: Cargo generate-lockfile
+        run: cargo generate-lockfile
+
+      - name: Cargo cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - run: echo ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Check for version requirement message
+        run: command 2>&1 cargo test web | grep -E "^[[:space:]]*sycamore@[[:digit:]]+(.[[:digit:]]+)* requires rustc [[:digit:]]+(.[[:digit:]]+)*"

--- a/packages/sycamore/Cargo.toml
+++ b/packages/sycamore/Cargo.toml
@@ -8,6 +8,7 @@ keywords = ["wasm", "gui", "reactive"]
 license = "MIT"
 readme = "../../README.md"
 repository = "https://github.com/sycamore-rs/sycamore"
+rust-version = "1.81"
 version.workspace = true
 
 [dependencies]


### PR DESCRIPTION
### Summary

On the branch to be merged, Cargo provides a helpful error message if you try to build a Sycamore app with a Rust toolchain below the minimum supported version. This is accomplished by setting [`rust-version`](https://doc.rust-lang.org/cargo/reference/rust-version.html) in the package description.

The new `msrv` job in the `test` workflow builds the `web` integration test on a Rust toolchain below the minimum supported version, and confirms that Cargo prints the expected error message. The Rust toolchain-version is hard-coded, and has to be updated by hand when the MSRV changes.

### Maintenance version

Updates to the MSRV will have to be reflected by hand in three places:

- The "Your First App" documentation page.
  - On the main branch, this is the only place that reflects the MSRV.
- The `rust-version` setting for the `sycamore` package.
- The below-minimum version for the `msrv` job in the `test` workflow.

### Future directions

I don't know the minimum supported Rust version for the feature-specific packages (`sycamore-core`, `sycamore-futures`, etc.), so I've only set `rust-version` for the `sycamore` package. It should be possible, however, to set independent MSRVs for different feature-specific packages in the same way.