### PR TITLE
Reimplement `is_ssr!` and `is_not_ssr!` macros to not trigger unknown cfg warning

### DIFF
--- a/docs/next/troubleshooting.md
+++ b/docs/next/troubleshooting.md
@@ -19,17 +19,3 @@ console_error_panic_hook::set_once();
 
 > Note: This section is a stub. Help us write this section!
 
-## unexpected `cfg` condition name: `sycamore_force_ssr`
-
-Sycamore uses a custom cfg (`sycamore_force_ssr`) to force the SSR mode. Because
-the compiler doesn't know about custom cfg it will emit warnings. To disables
-those warnings, add the following lints configuration in the `Cargo.toml` file
-of your project.
-
-```toml
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ["cfg(sycamore_force_ssr)"] }
-```
-
-More information here:
-<https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#check-cfg-in-lintsrust-table>

--- a/examples/ssr-streaming/src/main.rs
+++ b/examples/ssr-streaming/src/main.rs
@@ -1,10 +1,9 @@
 mod app;
-cfg_ssr_item!(
+is_ssr!(
     mod server;
 );
 
 use sycamore::prelude::*;
-use sycamore::web::cfg_ssr_item;
 
 #[cfg_ssr]
 #[tokio::main]

--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -181,21 +181,21 @@ macro_rules! is_not_ssr {
 
 /// `macro_rules!` equivalent of [`cfg_ssr`]. This is to get around the limitation of not being
 /// able to put proc-macros on `mod` items.
+#[deprecated(since = "0.9.2", note = "use `is_ssr!` instead")]
 #[macro_export]
 macro_rules! cfg_ssr_item {
     ($item:item) => {
-        #[cfg(any(not(target_arch = "wasm32"), sycamore_force_ssr))]
-        $item
+        $crate::is_ssr! { $item }
     };
 }
 
 /// `macro_rules!` equivalent of [`cfg_not_ssr`]. This is to get around the limitation of not being
 /// able to put proc-macros on `mod` items.
+#[deprecated(since = "0.9.2", note = "use `is_not_ssr!` instead")]
 #[macro_export]
 macro_rules! cfg_not_ssr_item {
     ($item:item) => {
-        #[cfg(all(target_arch = "wasm32", not(sycamore_force_ssr)))]
-        $item
+        $crate::is_not_ssr! { $item }
     };
 }
 

--- a/packages/sycamore-web/src/node/mod.rs
+++ b/packages/sycamore-web/src/node/mod.rs
@@ -5,14 +5,12 @@ use std::num::NonZeroU32;
 
 use crate::*;
 
-cfg_not_ssr_item!(
+is_not_ssr!(
     mod dom_node;
-);
-cfg_not_ssr_item!(
     #[cfg(feature = "hydrate")]
     mod hydrate_node;
 );
-cfg_ssr_item!(
+is_ssr!(
     mod ssr_node;
 );
 mod dom_render;


### PR DESCRIPTION
This is a better fix to #792 

Also deprecates `cfg_ssr_item!` and `cfg_not_ssr_item!` since they can just be replaced by `is_ssr!` and `is_not_ssr!`.