### PR TITLE
Fix `#[cfg_ssr]` and `#[cfg_not_ssr]` to use `is_ssr!` and `is_not_ssr!` macros.

### DIFF
--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -73,8 +73,9 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
 pub fn cfg_ssr(_args: TokenStream, input: TokenStream) -> TokenStream {
     let input: proc_macro2::TokenStream = input.into();
     quote! {
-        #[cfg(any(not(target_arch = "wasm32"), sycamore_force_ssr))]
-        #input
+        ::sycamore::web::is_ssr! {
+            #input
+        }
     }
     .into()
 }
@@ -97,8 +98,9 @@ pub fn cfg_ssr(_args: TokenStream, input: TokenStream) -> TokenStream {
 pub fn cfg_not_ssr(_args: TokenStream, input: TokenStream) -> TokenStream {
     let input: proc_macro2::TokenStream = input.into();
     quote! {
-        #[cfg(all(target_arch = "wasm32", not(sycamore_force_ssr)))]
-        #input
+        ::sycamore::web::is_not_ssr! {
+            #input
+        }
     }
     .into()
 }

--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -69,7 +69,11 @@ pub use self::suspense::*;
 pub use self::view::*;
 
 /// We add this to make the macros from `sycamore-macro` work properly.
+/// We also add the `web` module so that the macros can access `::sycamore::web` correctly.
 extern crate self as sycamore;
+mod web {
+    pub use crate::*;
+}
 
 #[doc(hidden)]
 pub mod rt {


### PR DESCRIPTION
Forgot to do this in #798 