### PR TITLE
Disable publishing in Cargo.toml for examples

### DIFF
--- a/examples/attributes-passthrough/Cargo.toml
+++ b/examples/attributes-passthrough/Cargo.toml
@@ -2,12 +2,10 @@
 name = "attributes-passthrough"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/components/Cargo.toml
+++ b/examples/components/Cargo.toml
@@ -2,12 +2,10 @@
 name = "components"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/context/Cargo.toml
+++ b/examples/context/Cargo.toml
@@ -2,12 +2,10 @@
 name = "context"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -2,12 +2,10 @@
 name = "counter"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/hello-builder/Cargo.toml
+++ b/examples/hello-builder/Cargo.toml
@@ -2,13 +2,11 @@
 name = "hello-builder"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -2,12 +2,10 @@
 name = "hello-world"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/higher-order-components/Cargo.toml
+++ b/examples/higher-order-components/Cargo.toml
@@ -2,12 +2,10 @@
 name = "higher-order-components"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/http-request-builder/Cargo.toml
+++ b/examples/http-request-builder/Cargo.toml
@@ -2,15 +2,13 @@
 name = "http-request-builder"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
 gloo-net = { version = "0.6.0", features = ["http"] }
 serde = { version = "1.0.147", features = ["derive"] }
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }
-
 
 [lints]
 workspace = true

--- a/examples/http-request/Cargo.toml
+++ b/examples/http-request/Cargo.toml
@@ -2,15 +2,13 @@
 name = "http-request"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
 gloo-net = { version = "0.6.0", features = ["http"] }
 serde = { version = "1.0.147", features = ["derive"] }
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }
-
 
 [lints]
 workspace = true

--- a/examples/hydrate/Cargo.toml
+++ b/examples/hydrate/Cargo.toml
@@ -2,8 +2,7 @@
 name = "hydrate"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 console_error_panic_hook = "0.1.7"

--- a/examples/iteration/Cargo.toml
+++ b/examples/iteration/Cargo.toml
@@ -2,12 +2,10 @@
 name = "iteration"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/js-framework-benchmark/Cargo.toml
+++ b/examples/js-framework-benchmark/Cargo.toml
@@ -2,15 +2,13 @@
 name = "js-framework-benchmark"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
 getrandom = { version = "0.2.8", features = ["js"] }
 rand = "0.8.5"
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/js-snippets/Cargo.toml
+++ b/examples/js-snippets/Cargo.toml
@@ -2,13 +2,11 @@
 name = "js-snippets"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
 wasm-bindgen = "0.2.83"
-
 
 [lints]
 workspace = true

--- a/examples/motion/Cargo.toml
+++ b/examples/motion/Cargo.toml
@@ -2,13 +2,11 @@
 name = "motion"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/number-binding/Cargo.toml
+++ b/examples/number-binding/Cargo.toml
@@ -2,12 +2,10 @@
 name = "number-binding"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -2,13 +2,11 @@
 name = "router"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
 sycamore-router = { path = "../../packages/sycamore-router" }
-
 
 [lints]
 workspace = true

--- a/examples/ssr-streaming/Cargo.toml
+++ b/examples/ssr-streaming/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ssr-streaming"
 edition = "2021"
 version.workspace = true
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore", features = [

--- a/examples/ssr-suspense/Cargo.toml
+++ b/examples/ssr-suspense/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ssr-suspense"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore", features = [

--- a/examples/ssr/Cargo.toml
+++ b/examples/ssr/Cargo.toml
@@ -2,12 +2,10 @@
 name = "ssr"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/svg/Cargo.toml
+++ b/examples/svg/Cargo.toml
@@ -2,12 +2,10 @@
 name = "svg"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 sycamore = { path = "../../packages/sycamore" }
-
 
 [lints]
 workspace = true

--- a/examples/timer/Cargo.toml
+++ b/examples/timer/Cargo.toml
@@ -2,13 +2,11 @@
 name = "timer"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 gloo-timers = { version = "0.2.4", features = ["futures"] }
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }
-
 
 [lints]
 workspace = true

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -2,8 +2,7 @@
 name = "todomvc"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
@@ -15,7 +14,6 @@ uuid = { version = "1.2.2", features = ["serde", "v4", "js"] }
 [dependencies.web-sys]
 features = ["Location", "Storage", "HtmlInputElement"]
 version = "0.3.60"
-
 
 [lints]
 workspace = true

--- a/examples/transitions/Cargo.toml
+++ b/examples/transitions/Cargo.toml
@@ -2,8 +2,7 @@
 name = "transitions"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+publish = false
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
@@ -11,7 +10,6 @@ getrandom = { version = "0.2.8", features = ["js"] }
 gloo-timers = { version = "0.2.4", features = ["futures"] }
 rand = "0.8.5"
 sycamore = { path = "../../packages/sycamore", features = ["suspense"] }
-
 
 [lints]
 workspace = true

--- a/packages/sycamore-core/Cargo.toml
+++ b/packages/sycamore-core/Cargo.toml
@@ -23,6 +23,5 @@ sycamore = { path = "../sycamore" }
 default = []
 suspense = ["sycamore-futures"]
 
-
 [lints]
 workspace = true

--- a/packages/sycamore-macro/Cargo.toml
+++ b/packages/sycamore-macro/Cargo.toml
@@ -28,6 +28,5 @@ trybuild = "1.0.71"
 [features]
 default = []
 
-
 [lints]
 workspace = true

--- a/packages/sycamore-reactive/Cargo.toml
+++ b/packages/sycamore-reactive/Cargo.toml
@@ -10,8 +10,6 @@ readme = "../../README.md"
 repository = "https://github.com/sycamore-rs/sycamore"
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 paste = "1.0.12"
 serde = { version = "1.0.188", optional = true }
@@ -24,7 +22,6 @@ default = []
 nightly = []
 serde = ["dep:serde"]
 wasm-bindgen = ["dep:wasm-bindgen"]
-
 
 [lints]
 workspace = true

--- a/packages/sycamore-router-macro/Cargo.toml
+++ b/packages/sycamore-router-macro/Cargo.toml
@@ -13,8 +13,6 @@ version.workspace = true
 [lib]
 proc-macro = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 proc-macro2 = "1.0.47"
 quote = "1.0.21"
@@ -24,7 +22,6 @@ syn = "2.0.10"
 expect-test = "1.4.0"
 sycamore-router = { path = "../sycamore-router" }
 trybuild = "1.0.71"
-
 
 [lints]
 workspace = true

--- a/packages/sycamore-router/Cargo.toml
+++ b/packages/sycamore-router/Cargo.toml
@@ -10,8 +10,6 @@ readme = "../../README.md"
 repository = "https://github.com/sycamore-rs/sycamore"
 version.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 sycamore = { workspace = true }
 sycamore-router-macro = { workspace = true }
@@ -32,7 +30,6 @@ features = [
 	"UrlSearchParams",
 ]
 version = "0.3.60"
-
 
 [lints]
 workspace = true

--- a/packages/sycamore-view-parser/Cargo.toml
+++ b/packages/sycamore-view-parser/Cargo.toml
@@ -15,6 +15,5 @@ proc-macro2 = "1.0.47"
 quote = "1.0.21"
 syn = { version = "2.0.10", features = ["extra-traits", "full"] }
 
-
 [lints]
 workspace = true

--- a/packages/sycamore-web/Cargo.toml
+++ b/packages/sycamore-web/Cargo.toml
@@ -82,6 +82,5 @@ hydrate = []
 suspense = ["dep:sycamore-futures", "dep:futures", "dep:async-stream"]
 wasm-bindgen-interning = ["wasm-bindgen/enable-interning"]
 
-
 [lints]
 workspace = true

--- a/packages/sycamore/Cargo.toml
+++ b/packages/sycamore/Cargo.toml
@@ -58,6 +58,5 @@ required-features = ["hydrate"]
 all-features = true
 default-target = "wasm32-unknown-unknown"
 
-
 [lints]
 workspace = true

--- a/packages/tools/bench-diff/Cargo.toml
+++ b/packages/tools/bench-diff/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.89"

--- a/packages/tools/bench/Cargo.toml
+++ b/packages/tools/bench/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2021"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 sycamore = { path = "../../sycamore" }
 


### PR DESCRIPTION
Adds the `publish = false` key to `Cargo.toml` for all examples