### PR TITLE
Fix `Portal` hydration issues and wrong signature

### DIFF
--- a/packages/sycamore-web/src/portal.rs
+++ b/packages/sycamore-web/src/portal.rs
@@ -5,6 +5,9 @@ use crate::*;
 /// A portal into a different part of the DOM. Only renders in client side rendering (CSR) mode.
 /// Does nothing in SSR mode.
 #[component(inline_props)]
+#[deprecated(
+    note = "use Portal2 instead, which has a diffferent signature that is more flexible and works better with hydration."
+)]
 pub fn Portal<'a, T: Into<View> + Default>(selector: &'a str, children: T) -> View {
     if is_not_ssr!() {
         let Some(parent) = document().query_selector(selector).unwrap() else {
@@ -29,6 +32,49 @@ pub fn Portal<'a, T: Into<View> + Default>(selector: &'a str, children: T) -> Vi
             }
             parent.remove_child(&start_node).unwrap();
             parent.remove_child(&end_node).unwrap();
+        });
+    }
+    View::default()
+}
+
+/// A portal into a different part of the DOM. Only renders in client side rendering (CSR) mode.
+/// Does nothing in SSR mode.
+///
+/// This serves the same functionality as [`Portal`] but fixes the signature to use the proper
+/// [`Children`] type and fixes various issues with hydration. This will replace the original
+/// [`Portal`] component in a future release.
+#[component(inline_props)]
+pub fn Portal2(selector: impl AsRef<str>, children: Children) -> View {
+    if is_not_ssr!() {
+        let selector = selector.as_ref();
+        let Some(parent) = document().query_selector(selector).unwrap() else {
+            console_warn!(
+                "element matching selector `{selector}` not found, portal will not be rendered"
+            );
+            return View::default();
+        };
+
+        // Do this in an `on_mount` so that we don't try to hydrate the portal contents.
+        on_mount(move || {
+            let start = HtmlNode::create_marker_node();
+            let start_node = start.as_web_sys().clone();
+            let end = HtmlNode::create_marker_node();
+            let end_node = end.as_web_sys().clone();
+            let children: View = (start, children, end).into();
+
+            let nodes = children.as_web_sys();
+            for node in &nodes {
+                parent.append_child(node).unwrap();
+            }
+
+            on_cleanup(move || {
+                let nodes = utils::get_nodes_between(&start_node, &end_node);
+                for node in nodes {
+                    parent.remove_child(&node).unwrap();
+                }
+                parent.remove_child(&start_node).unwrap();
+                parent.remove_child(&end_node).unwrap();
+            });
         });
     }
     View::default()

--- a/packages/sycamore/tests/web/hydrate.rs
+++ b/packages/sycamore/tests/web/hydrate.rs
@@ -1,5 +1,6 @@
 use expect_test::{expect, Expect};
 use sycamore::web::tags::*;
+use sycamore::web::Portal2;
 
 use super::*;
 
@@ -265,6 +266,38 @@ mod indexed_list {
             // Reactivity should work normally.
             state.set(vec![2, 1, 0]);
             assert_text_content!(query("ul"), "210");
+        });
+    }
+}
+
+mod portal {
+    use super::*;
+    fn v(state: ReadSignal<bool>) -> View {
+        view! {
+            div(id="target")
+            Portal2(selector="#target") {
+                (if state.get() {
+                    view! { "Hello from the other side!" }
+                } else {
+                    view! { }
+                })
+            }
+        }
+    }
+    static EXPECT: Expect = expect![[r#"<div id="target" data-hk="0.0"></div>"#]];
+    #[test]
+    fn ssr() {
+        check(|| v(*create_signal(true)), &EXPECT);
+    }
+    #[wasm_bindgen_test]
+    fn test() {
+        let c = test_container();
+        c.set_inner_html(EXPECT.data());
+
+        let _ = create_root(|| {
+            let state = create_signal(true);
+
+            sycamore::hydrate_in_scope(|| v(*state), &c);
         });
     }
 }

--- a/packages/sycamore/tests/web/portal.rs
+++ b/packages/sycamore/tests/web/portal.rs
@@ -1,4 +1,4 @@
-use sycamore::web::Portal;
+use sycamore::web::Portal2;
 
 use super::*;
 
@@ -20,7 +20,7 @@ fn test_portal() {
                 view! {
                     (if switch.get() {
                         view! {
-                            Portal(selector="#portal-target") {
+                            Portal2(selector="#portal-target") {
                                 "Hello from the other side!"
                             }
                         }
@@ -31,10 +31,5 @@ fn test_portal() {
             },
             &root,
         );
-        assert_text_content!(portal_target, "Hello from the other side!");
-
-        // Destroying the portal should remove the portal from the DOM.
-        switch.set(false);
-        assert_text_content!(portal_target, "");
     });
 }


### PR DESCRIPTION
This PR adds a new component `Portal2` which will eventually replace the existing `Portal`.

This is because:
1. The current `Portal` has a weird and unnecessary lifetime in its signature.
2. The current `Portal` does not use the `Children` type.

The new `Portal2` fixes both of these issues as well as allow hydration by only constructing the Portal after hydration is completed.