### PR TITLE
Update links to new website in docs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,10 +1,10 @@
 # Examples
 
-## Viewing on `sycamore-rs.netlify.app`
+## Live Demos
 
 All the examples are hosted under `examples.sycamore.dev/<example_name>` with
-`<example_name>` being the name of the example you want to view. For instance, the `todomvc` example
-is hosted on
+`<example_name>` replaced with the name of the example you want to view. For instance, the `todomvc` example
+can be viewed at
 [`examples.sycamore.dev/todomvc`](https://examples.sycamore.dev/todomvc).
 
 ## Building Locally
@@ -17,7 +17,7 @@ cd examples/todomvc
 trunk serve
 ```
 
-Now open up `localhost:8080` in your browser to see "Hello World!".
+Now open up `localhost:8080` in your browser to see the example running locally.
 
 ## Example List
 

--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -1,4 +1,4 @@
-//! Proc-macros used in [Sycamore](https://sycamore-rs.netlify.app).
+//! Proc-macros used in [Sycamore](https://docs.rs/sycamore).
 
 #![deny(missing_debug_implementations)]
 #![warn(missing_docs)]
@@ -13,8 +13,8 @@ mod props;
 
 /// A macro for ergonomically creating complex UI complex layouts.
 ///
-/// To learn more about the view syntax, see [the chapter on views](https://sycamore-rs.netlify.app/docs/basics/view)
-/// in the Sycamore Book.
+/// To learn more about the view syntax, see [the chapter on the view
+/// macro](https://sycamore.dev/book/guide/view-dsl) in the Sycamore Book.
 #[proc_macro]
 pub fn view(input: TokenStream) -> TokenStream {
     let root = parse_macro_input!(input as sycamore_view_parser::ir::Root);
@@ -27,7 +27,7 @@ pub fn view(input: TokenStream) -> TokenStream {
 /// Add this attribute to a `fn` to create a component from that function.
 ///
 /// To learn more about components, see the chapter on
-/// [components](https://sycamore-rs.netlify.app/docs/basics/components) in the Sycamore Book.
+/// [components](https://sycamore.dev/book/introduction/your-first-app#using-components) in the Sycamore Book.
 #[proc_macro_attribute]
 pub fn component(args: TokenStream, item: TokenStream) -> TokenStream {
     let args = parse_macro_input!(args as component::ComponentArgs);

--- a/packages/sycamore-web/src/suspense.rs
+++ b/packages/sycamore-web/src/suspense.rs
@@ -27,11 +27,11 @@ pub struct SuspenseProps {
 /// `Suspense` lets you wait for `async` tasks to complete before rendering the UI. This is useful
 /// for asynchronous data-fetching or other asynchronous tasks.
 ///
-/// `Suspense` is deeply integrated with [async components](https://sycamore-rs.netlify.app/docs/basics/components).
-/// Async components that are nested under the `Suspense` component will not be rendered until they
-/// are resolved. Having multiple async components will have the effect that the final UI will only
-/// be rendered once all individual async components are rendered. This is useful for showing a
-/// loading indicator while the data is being loaded.
+/// `Suspense` is deeply integrated with async components. Async components that are nested under
+/// the `Suspense` component will not be rendered until they are resolved. Having multiple async
+/// components will have the effect that the final UI will only be rendered once all individual
+/// async components are rendered. This is useful for showing a loading indicator while the data is
+/// being loaded.
 ///
 /// # Example
 /// ```

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! Sycamore is a **reactive** library for creating web apps in **Rust** and **WebAssembly**.
 //!
-//! This is the API docs for sycamore. If you are looking for the usage docs, checkout the
-//! [Sycamore Book](https://sycamore-rs.netlify.app/docs/getting_started/installation).
+//! This is the API docs for sycamore. If you are looking for the usage docs, check out the
+//! [Sycamore Book](https://sycamore.dev/book/introduction).
 //!
 //! ## Feature Flags
 //!


### PR DESCRIPTION
Some links in the docs were still point to sycamore-rs.netlify.app instead of sycamore.dev