### PR TITLE
Fix panic when signal is disposed when tracked

### DIFF
--- a/packages/sycamore-reactive/src/root.rs
+++ b/packages/sycamore-reactive/src/root.rs
@@ -633,4 +633,18 @@ mod tests {
             assert_eq!(counter.get(), 2);
         });
     }
+
+    #[test]
+    fn issue_741_disposing_signal_inside_effect_should_not_panic() {
+        let _ = create_root(|| {
+            let a = create_signal(0);
+            let b = create_signal(0);
+            create_effect(move || {
+                a.track();
+                b.track();
+                a.dispose();
+            });
+            b.set(0);
+        });
+    }
 }

--- a/packages/sycamore-reactive/src/root.rs
+++ b/packages/sycamore-reactive/src/root.rs
@@ -146,9 +146,9 @@ impl Root {
         // Remove old dependency links.
         let dependencies = std::mem::take(&mut self.nodes.borrow_mut()[current].dependencies);
         for dependency in dependencies {
-            self.nodes.borrow_mut()[dependency]
-                .dependents
-                .retain(|&id| id != current);
+            if let Some(node) = self.nodes.borrow_mut().get_mut(dependency) {
+                node.dependents.retain(|&id| id != current);
+            }
         }
         // We take the callback out because that requires a mut ref and we cannot hold that while
         // running update itself.
@@ -325,7 +325,9 @@ impl DependencyTracker {
     /// `dependencies` of the `dependent`.
     pub fn create_dependency_link(self, root: &Root, dependent: NodeId) {
         for node in &self.dependencies {
-            root.nodes.borrow_mut()[*node].dependents.push(dependent);
+            if let Some(node) = root.nodes.borrow_mut().get_mut(*node) {
+                node.dependents.push(dependent)
+            }
         }
         // Set the signal dependencies so that it is updated automatically.
         root.nodes.borrow_mut()[dependent].dependencies = self.dependencies;


### PR DESCRIPTION
Fixes #741 

If a signal has already been disposed, simply ignores it completely.
This applies to both establishing back links for dependency tracking as well as when propagating updates.