### PR TITLE
Migrate to Edition 2024 and use cargo workspace keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 members = [
 	# Packages
 	"packages/sycamore",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,12 @@ default-members = [
 ]
 
 [workspace.package]
+edition = "2024"
+rust-version = "1.94"
+license = "MIT"
+readme = "README.md"
+repository = "https://github.com/sycamore-rs/sycamore"
+homepage = "https://github.com/sycamore-rs/sycamore"
 version = "0.9.2"
 
 [workspace.dependencies]

--- a/examples/attributes-passthrough/Cargo.toml
+++ b/examples/attributes-passthrough/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "attributes-passthrough"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/components/Cargo.toml
+++ b/examples/components/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "components"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/context/Cargo.toml
+++ b/examples/context/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "context"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "counter"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/hello-builder/Cargo.toml
+++ b/examples/hello-builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello-builder"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hello-world"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/higher-order-components/Cargo.toml
+++ b/examples/higher-order-components/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "higher-order-components"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/http-request-builder/Cargo.toml
+++ b/examples/http-request-builder/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-request-builder"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/http-request/Cargo.toml
+++ b/examples/http-request/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "http-request"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/hydrate/Cargo.toml
+++ b/examples/hydrate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hydrate"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/iteration/Cargo.toml
+++ b/examples/iteration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iteration"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/js-framework-benchmark/Cargo.toml
+++ b/examples/js-framework-benchmark/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "js-framework-benchmark"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/js-snippets/Cargo.toml
+++ b/examples/js-snippets/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "js-snippets"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/motion/Cargo.toml
+++ b/examples/motion/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "motion"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/number-binding/Cargo.toml
+++ b/examples/number-binding/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "number-binding"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/router/Cargo.toml
+++ b/examples/router/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "router"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/router/src/main.rs
+++ b/examples/router/src/main.rs
@@ -1,5 +1,5 @@
 use sycamore::prelude::*;
-use sycamore_router::{use_search_query, HistoryIntegration, Route, Router};
+use sycamore_router::{HistoryIntegration, Route, Router, use_search_query};
 
 #[derive(Route, Clone)]
 enum AppRoutes {

--- a/examples/ssr-streaming/Cargo.toml
+++ b/examples/ssr-streaming/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ssr-streaming"
-edition = "2021"
-version.workspace = true
+version = "0.1.0"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/ssr-suspense/Cargo.toml
+++ b/examples/ssr-suspense/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ssr-suspense"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/ssr/Cargo.toml
+++ b/examples/ssr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ssr"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/svg/Cargo.toml
+++ b/examples/svg/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "svg"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/timer/Cargo.toml
+++ b/examples/timer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "timer"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "todomvc"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/transitions/Cargo.toml
+++ b/examples/transitions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "transitions"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/examples/transitions/src/main.rs
+++ b/examples/transitions/src/main.rs
@@ -1,7 +1,7 @@
 use gloo_timers::future::TimeoutFuture;
 use rand::Rng;
 use sycamore::prelude::*;
-use sycamore::web::{create_client_resource, Suspense, Transition};
+use sycamore::web::{Suspense, Transition, create_client_resource};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Tab {
@@ -13,9 +13,15 @@ enum Tab {
 impl Tab {
     fn content(self) -> &'static str {
         match self {
-            Tab::One => "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Bibendum est ultricies integer quis auctor elit sed. Sed egestas egestas fringilla phasellus faucibus scelerisque eleifend.",
-            Tab::Two => "Auctor urna nunc id cursus. Sed viverra tellus in hac habitasse. Non blandit massa enim nec dui nunc mattis. Orci ac auctor augue mauris augue neque. Facilisi cras fermentum odio eu feugiat pretium nibh ipsum.",
-            Tab::Three => "Tristique senectus et netus et malesuada fames. Purus in massa tempor nec feugiat nisl pretium fusce. Phasellus faucibus scelerisque eleifend donec. Eget nullam non nisi est sit. Sit amet justo donec enim diam vulputate ut pharetra. Ante in nibh mauris cursus. Quis risus sed vulputate odio ut enim blandit volutpat maecenas.",
+            Tab::One => {
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Bibendum est ultricies integer quis auctor elit sed. Sed egestas egestas fringilla phasellus faucibus scelerisque eleifend."
+            }
+            Tab::Two => {
+                "Auctor urna nunc id cursus. Sed viverra tellus in hac habitasse. Non blandit massa enim nec dui nunc mattis. Orci ac auctor augue mauris augue neque. Facilisi cras fermentum odio eu feugiat pretium nibh ipsum."
+            }
+            Tab::Three => {
+                "Tristique senectus et netus et malesuada fames. Purus in massa tempor nec feugiat nisl pretium fusce. Phasellus faucibus scelerisque eleifend donec. Eget nullam non nisi est sit. Sit amet justo donec enim diam vulputate ut pharetra. Ante in nibh mauris cursus. Quis risus sed vulputate odio ut enim blandit volutpat maecenas."
+            }
         }
     }
 }

--- a/packages/sycamore-core/Cargo.toml
+++ b/packages/sycamore-core/Cargo.toml
@@ -2,12 +2,13 @@
 name = "sycamore-core"
 categories = ["gui", "wasm", "web-programming"]
 description = "Core functionality for the SycamoreS"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
+edition.workspace = true
+rust-version.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/packages/sycamore-futures/Cargo.toml
+++ b/packages/sycamore-futures/Cargo.toml
@@ -2,12 +2,12 @@
 name = "sycamore-futures"
 categories = ["gui", "wasm", "web-programming"]
 description = "Futures, suspense, and async/await support for Sycamore"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/packages/sycamore-futures/src/lib.rs
+++ b/packages/sycamore-futures/src/lib.rs
@@ -8,11 +8,11 @@ mod suspense;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use futures::Future;
 use futures::future::abortable;
 use futures::stream::Abortable;
-use futures::Future;
 use pin_project::pin_project;
-use sycamore_reactive::{on_cleanup, use_current_scope, NodeHandle};
+use sycamore_reactive::{NodeHandle, on_cleanup, use_current_scope};
 
 pub use self::suspense::*;
 

--- a/packages/sycamore-futures/src/suspense.rs
+++ b/packages/sycamore-futures/src/suspense.rs
@@ -70,10 +70,10 @@ impl SuspenseScope {
         let (tx, rx) = oneshot::channel();
         let mut tx = Some(tx);
         create_effect(move || {
-            if !self._is_loading() {
-                if let Some(tx) = tx.take() {
-                    tx.send(()).unwrap();
-                }
+            if !self._is_loading()
+                && let Some(tx) = tx.take()
+            {
+                tx.send(()).unwrap();
             }
         });
 

--- a/packages/sycamore-futures/src/suspense.rs
+++ b/packages/sycamore-futures/src/suspense.rs
@@ -3,8 +3,8 @@
 //! The [`Suspense`] component is used to "suspend" execution and wait until async tasks are
 //! finished before rendering.
 
-use futures::channel::oneshot;
 use futures::Future;
+use futures::channel::oneshot;
 use sycamore_reactive::*;
 
 use crate::*;

--- a/packages/sycamore-macro/Cargo.toml
+++ b/packages/sycamore-macro/Cargo.toml
@@ -2,12 +2,12 @@
 name = "sycamore-macro"
 categories = ["gui", "wasm", "web-programming"]
 description = "proc-macro crate for Sycamore"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [lib]

--- a/packages/sycamore-macro/src/component.rs
+++ b/packages/sycamore-macro/src/component.rs
@@ -56,15 +56,14 @@ impl Parse for ComponentFn {
                             ));
                         }
 
-                        if let FnArg::Typed(pat) = input {
-                            if let Type::Tuple(TypeTuple { elems, .. }) = &*pat.ty {
-                                if elems.is_empty() {
-                                    return Err(syn::Error::new(
-                                        pat.ty.span(),
-                                        "taking an unit tuple as props is useless",
-                                    ));
-                                }
-                            }
+                        if let FnArg::Typed(pat) = input
+                            && let Type::Tuple(TypeTuple { elems, .. }) = &*pat.ty
+                            && elems.is_empty()
+                        {
+                            return Err(syn::Error::new(
+                                pat.ty.span(),
+                                "taking an unit tuple as props is useless",
+                            ));
                         }
                     }
                     [..] => {

--- a/packages/sycamore-macro/src/component.rs
+++ b/packages/sycamore-macro/src/component.rs
@@ -1,13 +1,13 @@
 //! The `#[component]` attribute macro implementation.
 
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote, ToTokens};
+use quote::{ToTokens, format_ident, quote};
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{
-    parse_quote, AttrStyle, Attribute, Error, Expr, FnArg, Generics, Ident, Item, ItemFn, Meta,
-    Pat, PatIdent, Result, ReturnType, Signature, Token, Type, TypeTuple,
+    AttrStyle, Attribute, Error, Expr, FnArg, Generics, Ident, Item, ItemFn, Meta, Pat, PatIdent,
+    Result, ReturnType, Signature, Token, Type, TypeTuple, parse_quote,
 };
 
 pub struct ComponentFn {
@@ -286,7 +286,7 @@ fn inline_props_impl(item: &mut ItemFn, attrs: Punctuated<Meta, Token![,]>) -> R
                 return Err(syn::Error::new(
                     receiver.span(),
                     "`self` cannot be a property",
-                ))
+                ));
             }
             FnArg::Typed(pat_type) => match *pat_type.pat {
                 Pat::Ident(ident_pat) => super::inline_props::push_field(
@@ -300,7 +300,7 @@ fn inline_props_impl(item: &mut ItemFn, attrs: Punctuated<Meta, Token![,]>) -> R
                     return Err(syn::Error::new(
                         pat_type.pat.span(),
                         "pattern must contain an identifier, properties cannot be unnamed",
-                    ))
+                    ));
                 }
             },
         }

--- a/packages/sycamore-macro/src/lib.rs
+++ b/packages/sycamore-macro/src/lib.rs
@@ -5,7 +5,7 @@
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{DeriveInput, parse_macro_input};
 
 mod component;
 mod inline_props;

--- a/packages/sycamore-macro/src/props.rs
+++ b/packages/sycamore-macro/src/props.rs
@@ -38,20 +38,20 @@ pub fn impl_derive_props(ast: &DeriveInput) -> Result<TokenStream> {
                 return Err(Error::new(
                     ast.span(),
                     "Props is not supported for tuple structs",
-                ))
+                ));
             }
             syn::Fields::Unit => {
                 return Err(Error::new(
                     ast.span(),
                     "Props is not supported for unit structs",
-                ))
+                ));
             }
         },
         syn::Data::Enum(_) => {
-            return Err(Error::new(ast.span(), "Props is not supported for enums"))
+            return Err(Error::new(ast.span(), "Props is not supported for enums"));
         }
         syn::Data::Union(_) => {
-            return Err(Error::new(ast.span(), "Props is not supported for unions"))
+            return Err(Error::new(ast.span(), "Props is not supported for unions"));
         }
     };
     Ok(data)
@@ -62,9 +62,9 @@ mod struct_info {
 
     use proc_macro2::TokenStream;
     use quote::quote;
+    use syn::Token;
     use syn::parse::Error;
     use syn::punctuated::Punctuated;
-    use syn::Token;
 
     use super::field_info::{AttributeBase, FieldBuilderAttr, FieldInfo};
     use super::util::{
@@ -156,9 +156,9 @@ mod struct_info {
 
         pub fn builder_creation_impl(&self) -> Result<TokenStream, Error> {
             let StructInfo {
-                ref vis,
-                ref name,
-                ref builder_name,
+                vis,
+                name,
+                builder_name,
                 ..
             } = self;
             let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
@@ -221,8 +221,8 @@ mod struct_info {
                     Some(ref doc) => quote!(#[doc = #doc]),
                     None => {
                         let doc = format!(
-                        "Builder for [`{name}`] instances.\n\nSee [`{name}::builder()`] for more info."
-                    );
+                            "Builder for [`{name}`] instances.\n\nSee [`{name}::builder()`] for more info."
+                        );
                         quote!(#[doc = #doc])
                     }
                 }
@@ -327,9 +327,7 @@ mod struct_info {
         }
 
         pub fn field_impl(&self, field: &FieldInfo) -> Result<TokenStream, Error> {
-            let StructInfo {
-                ref builder_name, ..
-            } = self;
+            let StructInfo { builder_name, .. } = self;
 
             let destructuring = self.included_fields().map(|f| {
                 if f.ordinal == field.ordinal {
@@ -342,8 +340,8 @@ mod struct_info {
             let reconstructing = self.included_fields().map(|f| f.name);
 
             let FieldInfo {
-                name: ref field_name,
-                ty: ref field_type,
+                name: field_name,
+                ty: field_type,
                 ..
             } = field;
             let mut ty_generics: Vec<syn::GenericArgument> = self
@@ -484,14 +482,11 @@ mod struct_info {
 
         pub fn required_field_impl(&self, field: &FieldInfo) -> Result<TokenStream, Error> {
             let StructInfo {
-                ref name,
-                ref builder_name,
-                ..
+                name, builder_name, ..
             } = self;
 
             let FieldInfo {
-                name: ref field_name,
-                ..
+                name: field_name, ..
             } = field;
             let mut builder_generics: Vec<syn::GenericArgument> = self
                 .generics
@@ -594,9 +589,9 @@ mod struct_info {
 
         pub fn build_method_impl(&self) -> TokenStream {
             let StructInfo {
-                ref name,
-                ref builder_name,
-                ref attributes,
+                name,
+                builder_name,
+                attributes,
                 ..
             } = self;
 
@@ -826,10 +821,10 @@ mod struct_info {
 mod field_info {
     use proc_macro2::{Span, TokenStream};
     use quote::quote;
+    use syn::Token;
     use syn::parse::Error;
     use syn::punctuated::Punctuated;
     use syn::spanned::Spanned;
-    use syn::Token;
 
     use super::util::{
         expr_to_single_string, ident_to_type, path_to_single_string, strip_raw_ident_prefix,

--- a/packages/sycamore-reactive/Cargo.toml
+++ b/packages/sycamore-reactive/Cargo.toml
@@ -2,12 +2,12 @@
 name = "sycamore-reactive"
 categories = ["gui", "wasm", "web-programming"]
 description = "Reactive primitives for Sycamore"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/packages/sycamore-reactive/src/context.rs
+++ b/packages/sycamore-reactive/src/context.rs
@@ -1,10 +1,10 @@
 //! Context values.
 
-use std::any::{type_name, Any};
+use std::any::{Any, type_name};
 
 use slotmap::Key;
 
-use crate::{create_child_scope, NodeId, Root};
+use crate::{NodeId, Root, create_child_scope};
 
 /// Provide a context value in this scope.
 ///

--- a/packages/sycamore-reactive/src/iter.rs
+++ b/packages/sycamore-reactive/src/iter.rs
@@ -92,14 +92,14 @@ where
                 disposers_tmp[new_end] = disposers[end].take();
             }
             debug_assert!(
-                    if end != 0 && new_end != 0 {
-                        (end == items.len() && new_end == new_items.len())
-                            || (items[end - 1] != new_items[new_end - 1])
-                    } else {
-                        true
-                    },
-                    "end and new_end are the last indexes where items[end - 1] != new_items[new_end - 1]"
-                );
+                if end != 0 && new_end != 0 {
+                    (end == items.len() && new_end == new_items.len())
+                        || (items[end - 1] != new_items[new_end - 1])
+                } else {
+                    true
+                },
+                "end and new_end are the last indexes where items[end - 1] != new_items[new_end - 1]"
+            );
 
             // 0) Prepare a map of indices in new_items. Scan backwards so we encounter them in
             // natural order.
@@ -166,9 +166,11 @@ where
         disposers.truncate(new_items.len());
 
         // 4) Save a copy of the mapped items for the next update.
-        debug_assert!([mapped.len(), disposers.len()]
-            .iter()
-            .all(|l| *l == new_items.len()));
+        debug_assert!(
+            [mapped.len(), disposers.len()]
+                .iter()
+                .all(|l| *l == new_items.len())
+        );
         items = new_items;
 
         mapped.clone()
@@ -255,9 +257,11 @@ where
             mapped.truncate(new_items.len());
 
             // Save a copy of the mapped items for the next update.
-            debug_assert!([mapped.len(), disposers.len()]
-                .iter()
-                .all(|l| *l == new_items.len()));
+            debug_assert!(
+                [mapped.len(), disposers.len()]
+                    .iter()
+                    .all(|l| *l == new_items.len())
+            );
             items = new_items;
         }
 

--- a/packages/sycamore-reactive/src/memos.rs
+++ b/packages/sycamore-reactive/src/memos.rs
@@ -2,7 +2,7 @@
 
 use std::cell::RefCell;
 
-use crate::{create_empty_signal, create_signal, ReadSignal, Root};
+use crate::{ReadSignal, Root, create_empty_signal, create_signal};
 
 /// Creates a memoized value from some signals.
 /// Unlike [`create_memo`], this function will not notify dependents of a
@@ -226,8 +226,8 @@ mod tests {
             assert_eq!(double.get(), 2);
             state.set(2);
             assert_eq!(double.get(), 2); // double value should still be true because state.get()
-                                         // was
-                                         // inside untracked
+            // was
+            // inside untracked
         });
     }
 

--- a/packages/sycamore-reactive/src/node.rs
+++ b/packages/sycamore-reactive/src/node.rs
@@ -5,7 +5,7 @@ use std::any::Any;
 use slotmap::new_key_type;
 use smallvec::SmallVec;
 
-use crate::{untrack_in_scope, Root};
+use crate::{Root, untrack_in_scope};
 
 new_key_type! {
     pub(crate) struct NodeId;

--- a/packages/sycamore-reactive/src/signals.rs
+++ b/packages/sycamore-reactive/src/signals.rs
@@ -309,8 +309,8 @@ impl<T> ReadSignal<T> {
             .value
             .as_ref()
             .expect("cannot read signal while updating");
-        let ret = f(value.downcast_ref().expect("wrong signal type"));
-        ret
+
+        f(value.downcast_ref().expect("wrong signal type"))
     }
 
     /// Get a value from the signal.

--- a/packages/sycamore-router-macro/Cargo.toml
+++ b/packages/sycamore-router-macro/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
+name = "sycamore-router-macro"
 categories = ["gui", "wasm", "web-programming"]
 description = "proc-macro crate for sycamore-router"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-name = "sycamore-router-macro"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [lib]

--- a/packages/sycamore-router-macro/src/lib.rs
+++ b/packages/sycamore-router-macro/src/lib.rs
@@ -7,7 +7,7 @@ mod parser;
 mod route;
 
 use proc_macro::TokenStream;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{DeriveInput, parse_macro_input};
 
 /// The `Route` procedural macro.
 ///

--- a/packages/sycamore-router-macro/src/parser.rs
+++ b/packages/sycamore-router-macro/src/parser.rs
@@ -64,7 +64,7 @@ pub fn parse_route(i: &str) -> Result<RoutePathAst> {
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::{Expect, expect};
 
     use super::*;
 

--- a/packages/sycamore-router-macro/src/route.rs
+++ b/packages/sycamore-router-macro/src/route.rs
@@ -1,10 +1,10 @@
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned, ToTokens};
+use quote::{ToTokens, quote, quote_spanned};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{DeriveInput, Fields, Ident, LitStr, Token, Variant};
 
-use crate::parser::{parse_route, RoutePathAst, SegmentAst};
+use crate::parser::{RoutePathAst, SegmentAst, parse_route};
 
 pub fn route_impl(input: DeriveInput) -> syn::Result<TokenStream> {
     let mut quoted = TokenStream::new();
@@ -120,8 +120,11 @@ fn impl_to(
     if expected_fields_len != variant.fields.len() {
         return Err(syn::Error::new(
             variant.fields.span(),
-            format!("mismatch between number of capture fields and variant fields (found {} capture field(s) and {} variant field(s))",
-            expected_fields_len, variant.fields.len()),
+            format!(
+                "mismatch between number of capture fields and variant fields (found {} capture field(s) and {} variant field(s))",
+                expected_fields_len,
+                variant.fields.len()
+            ),
         ));
     }
 

--- a/packages/sycamore-router/Cargo.toml
+++ b/packages/sycamore-router/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
+name = "sycamore-router"
 categories = ["gui", "wasm", "web-programming"]
 description = "Router for Sycamore"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-name = "sycamore-router"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/packages/sycamore-router/src/lib.rs
+++ b/packages/sycamore-router/src/lib.rs
@@ -106,11 +106,8 @@ impl RoutePath {
                     }
                 }
                 Segment::DynParam => {
-                    if let Some(p) = paths.next() {
-                        captures.push(Capture::DynParam(p));
-                    } else {
-                        return None;
-                    }
+                    let p = paths.next()?;
+                    captures.push(Capture::DynParam(p));
                 }
                 Segment::DynSegments => {
                     if let Some(next_segment) = segments.next() {

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -510,8 +510,6 @@ fn meta_keys_pressed(kb_event: &KeyboardEvent) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use sycamore::prelude::*;
-
     use super::*;
 
     #[test]

--- a/packages/sycamore-view-parser/Cargo.toml
+++ b/packages/sycamore-view-parser/Cargo.toml
@@ -2,12 +2,12 @@
 name = "sycamore-view-parser"
 categories = ["gui", "wasm", "web-programming"]
 description = "parser for Sycamore view syntax"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/packages/sycamore-view-parser/src/parse.rs
+++ b/packages/sycamore-view-parser/src/parse.rs
@@ -3,7 +3,7 @@
 use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream};
 use syn::token::{Brace, Paren};
-use syn::{braced, parenthesized, token, Ident, LitStr, Result, Token};
+use syn::{Ident, LitStr, Result, Token, braced, parenthesized, token};
 
 use crate::ir::*;
 

--- a/packages/sycamore-web/Cargo.toml
+++ b/packages/sycamore-web/Cargo.toml
@@ -2,12 +2,12 @@
 name = "sycamore-web"
 categories = ["gui", "wasm", "web-programming"]
 description = "proc-macro crate for Sycamore"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/packages/sycamore-web/src/attributes.rs
+++ b/packages/sycamore-web/src/attributes.rs
@@ -117,7 +117,7 @@ impl Attributes {
 
 #[cfg(test)]
 mod tests {
-    use expect_test::{expect, Expect};
+    use expect_test::{Expect, expect};
 
     use super::*;
 

--- a/packages/sycamore-web/src/components.rs
+++ b/packages/sycamore-web/src/components.rs
@@ -1,6 +1,6 @@
 //! Definition for the [`NoSsr`] and [`NoHydrate`] components.
 
-use sycamore_macro::{component, view, Props};
+use sycamore_macro::{Props, component, view};
 
 use crate::*;
 

--- a/packages/sycamore-web/src/iter.rs
+++ b/packages/sycamore-web/src/iter.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Deref;
 
-use sycamore_macro::{component, Props};
+use sycamore_macro::{Props, component};
 use wasm_bindgen::prelude::*;
 
 use crate::*;

--- a/packages/sycamore-web/src/lib.rs
+++ b/packages/sycamore-web/src/lib.rs
@@ -87,7 +87,7 @@ pub mod rt {
 
     #[cfg(feature = "suspense")]
     pub use crate::WrapAsync;
-    pub use crate::{bind, custom_element, tags, View};
+    pub use crate::{View, bind, custom_element, tags};
 }
 
 /// Re-export of `js-sys` and `wasm-bindgen` for convenience.

--- a/packages/sycamore-web/src/node/ssr_render.rs
+++ b/packages/sycamore-web/src/node/ssr_render.rs
@@ -125,11 +125,10 @@ pub async fn render_to_string_await_suspense(f: impl FnOnce() -> View) -> String
 
                     // Now we wait until all suspense has resolved.
                     create_effect(move || {
-                        if !use_is_loading_global() {
-                            if let Some(tx) = tx.take() {
+                        if !use_is_loading_global()
+                            && let Some(tx) = tx.take() {
                                 tx.send(()).ok().unwrap();
                             }
-                        }
                     });
                 });
             });

--- a/packages/sycamore-web/src/resource.rs
+++ b/packages/sycamore-web/src/resource.rs
@@ -155,10 +155,10 @@ mod tests {
 
                 // Signal when the resource is loaded.
                 create_effect(move || {
-                    if !resource.unwrap().is_loading() {
-                        if let Some(tx) = tx.take() {
-                            tx.send(()).unwrap();
-                        }
+                    if !resource.unwrap().is_loading()
+                        && let Some(tx) = tx.take()
+                    {
+                        tx.send(()).unwrap();
                     }
                 })
             });

--- a/packages/sycamore-web/src/stable_counter.rs
+++ b/packages/sycamore-web/src/stable_counter.rs
@@ -3,7 +3,7 @@
 //!
 //! This works internally by using the context API to store the current value of the counter.
 
-use sycamore_reactive::{use_context_or_else, use_global_scope, Signal};
+use sycamore_reactive::{Signal, use_context_or_else, use_global_scope};
 
 #[derive(Debug, Default, Clone, Copy)]
 struct CounterValue {

--- a/packages/sycamore-web/src/suspense.rs
+++ b/packages/sycamore-web/src/suspense.rs
@@ -6,7 +6,7 @@ use std::num::NonZeroU32;
 use sycamore_futures::{
     create_detached_suspense_scope, create_suspense_scope, create_suspense_task,
 };
-use sycamore_macro::{component, Props};
+use sycamore_macro::{Props, component};
 
 use crate::*;
 

--- a/packages/sycamore-web/src/view.rs
+++ b/packages/sycamore-web/src/view.rs
@@ -2,7 +2,7 @@
 
 use std::fmt;
 
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 use sycamore_core::Children;
 
 use crate::*;
@@ -132,7 +132,9 @@ macro_rules! impl_view_from_to_string {
 }
 
 impl_view_from!(&'static str, String, Cow<'static, str>);
-impl_view_from_to_string!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64);
+impl_view_from_to_string!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64
+);
 
 impl<T: ViewNode, F: FnMut() -> U + 'static, U: Into<View<T>> + 'static> From<F> for View<T> {
     fn from(f: F) -> Self {

--- a/packages/sycamore/Cargo.toml
+++ b/packages/sycamore/Cargo.toml
@@ -2,13 +2,12 @@
 name = "sycamore"
 categories = ["gui", "wasm", "web-programming"]
 description = "A library for building reactive web apps in Rust and WebAssembly"
-edition = "2021"
-homepage = "https://github.com/sycamore-rs/sycamore"
 keywords = ["wasm", "gui", "reactive"]
-license = "MIT"
-readme = "../../README.md"
-repository = "https://github.com/sycamore-rs/sycamore"
-rust-version = "1.94"
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
 version.workspace = true
 
 [dependencies]

--- a/packages/sycamore/src/lib.rs
+++ b/packages/sycamore/src/lib.rs
@@ -93,9 +93,9 @@ pub mod prelude {
     pub use sycamore_web::tags::svg_attributes::*;
     #[cfg(feature = "web")]
     pub use sycamore_web::{
-        console_dbg, console_log, create_node_ref, document, is_not_ssr, is_ssr, on_mount, window,
         Attributes, Children, GlobalAttributes, GlobalProps, HtmlGlobalAttributes, Indexed, Keyed,
-        NodeRef, SvgGlobalAttributes, View,
+        NodeRef, SvgGlobalAttributes, View, console_dbg, console_log, create_node_ref, document,
+        is_not_ssr, is_ssr, on_mount, window,
     };
 
     pub use crate::reactive::*;
@@ -104,7 +104,7 @@ pub mod prelude {
 /// Re-exports for use by `sycamore-macro`. Not intended for use by end-users.
 #[doc(hidden)]
 pub mod rt {
-    pub use sycamore_core::{component_scope, element_like_component_builder, Component, Props};
+    pub use sycamore_core::{Component, Props, component_scope, element_like_component_builder};
     #[cfg(feature = "suspense")]
     pub use sycamore_futures::*;
     pub use sycamore_macro::*;

--- a/packages/sycamore/src/motion.rs
+++ b/packages/sycamore/src/motion.rs
@@ -132,7 +132,9 @@ macro_rules! impl_lerp_for_int {
     };
 }
 
-impl_lerp_for_int!(i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize);
+impl_lerp_for_int!(
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize
+);
 
 impl<T: Lerp + Clone, const N: usize> Lerp for [T; N] {
     fn lerp(&self, other: &Self, scalar: f32) -> Self {

--- a/packages/sycamore/tests/web/hydrate.rs
+++ b/packages/sycamore/tests/web/hydrate.rs
@@ -1,6 +1,6 @@
-use expect_test::{expect, Expect};
-use sycamore::web::tags::*;
+use expect_test::{Expect, expect};
 use sycamore::web::Portal2;
+use sycamore::web::tags::*;
 
 use super::*;
 

--- a/packages/tools/bench-diff/Cargo.toml
+++ b/packages/tools/bench-diff/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bench-diff"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/packages/tools/bench/Cargo.toml
+++ b/packages/tools/bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bench"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]

--- a/packages/tools/bench/benches/reactivity.rs
+++ b/packages/tools/bench/benches/reactivity.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{BatchSize, Criterion, black_box, criterion_group, criterion_main};
 use sycamore::reactive::*;
 
 pub fn bench(c: &mut Criterion) {

--- a/packages/tools/bench/benches/ssr.rs
+++ b/packages/tools/bench/benches/ssr.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use sycamore::prelude::*;
 
 pub fn bench(c: &mut Criterion) {


### PR DESCRIPTION
Long overdue migration to Rust Edition 2024. Also migrates `Cargo.toml` to use workspace keys in more places.