### PR TITLE
Warning when signal is accessed in component body

### DIFF
--- a/packages/sycamore-core/src/component.rs
+++ b/packages/sycamore-core/src/component.rs
@@ -5,11 +5,11 @@ use std::fmt;
 use sycamore_reactive::*;
 
 /// Runs the given closure inside a new component scope. In other words, this does the following:
-/// * Create a new untracked scope (see [`untrack`]).
+/// * Create a new untracked scope (see [`untrack_in_component`]).
 /// * Call the closure `f` passed to this function.
 #[doc(hidden)]
 pub fn component_scope<T>(f: impl FnOnce() -> T) -> T {
-    untrack(f)
+    untrack_in_component(f)
 }
 
 /// A trait that is implemented automatically by the `Props` derive macro.

--- a/packages/sycamore-reactive/src/root.rs
+++ b/packages/sycamore-reactive/src/root.rs
@@ -105,7 +105,9 @@ impl Root {
     /// Run the provided closure in a tracked scope. This will detect all the signals that are
     /// accessed and track them in a dependency list.
     pub fn tracked_scope<T>(&self, f: impl FnOnce() -> T) -> (T, DependencyTracker) {
-        let prev = self.tracker.replace(MaybeDependencyTracker::Tracking(DependencyTracker::default()));
+        let prev = self.tracker.replace(MaybeDependencyTracker::Tracking(
+            DependencyTracker::default(),
+        ));
         let ret = f();
         (ret, self.tracker.replace(prev).into_tracker().unwrap())
     }
@@ -479,7 +481,11 @@ pub(crate) fn untrack_in_scope<T>(f: impl FnOnce() -> T, root: &'static Root) ->
     untrack_in_scope_with_maybe_tracker(f, root, MaybeDependencyTracker::Untracked)
 }
 
-fn untrack_in_scope_with_maybe_tracker<T>(f: impl FnOnce() -> T, root: &'static Root, maybe_tracker: MaybeDependencyTracker) -> T {
+fn untrack_in_scope_with_maybe_tracker<T>(
+    f: impl FnOnce() -> T,
+    root: &'static Root,
+    maybe_tracker: MaybeDependencyTracker,
+) -> T {
     let prev = root.tracker.replace(maybe_tracker);
     let ret = f();
     root.tracker.replace(prev);
@@ -488,7 +494,11 @@ fn untrack_in_scope_with_maybe_tracker<T>(f: impl FnOnce() -> T, root: &'static 
 
 /// Same as [`untrack`] but creates warnings if any tracking is performed.
 pub fn untrack_in_component<T>(f: impl FnOnce() -> T) -> T {
-    untrack_in_scope_with_maybe_tracker(f, Root::global(), MaybeDependencyTracker::UntrackedInComponent)
+    untrack_in_scope_with_maybe_tracker(
+        f,
+        Root::global(),
+        MaybeDependencyTracker::UntrackedInComponent,
+    )
 }
 
 /// Get a handle to the current reactive scope.

--- a/packages/sycamore-reactive/src/root.rs
+++ b/packages/sycamore-reactive/src/root.rs
@@ -19,8 +19,8 @@ use crate::*;
 /// itself. Finally, the `Root` is expected to live for the whole duration of the app so this is
 /// not a problem.
 pub(crate) struct Root {
-    /// If this is `Some`, that means we are tracking signal accesses.
-    pub tracker: RefCell<Option<DependencyTracker>>,
+    /// If this is `MaybeDependencyTracker::Tracking`, that means we are tracking signal accesses.
+    pub tracker: RefCell<MaybeDependencyTracker>,
     /// A temporary buffer used in `propagate_updates` to prevent allocating a new Vec every time
     /// it is called.
     pub rev_sorted_buf: RefCell<Vec<NodeId>>,
@@ -59,7 +59,7 @@ impl Root {
     /// Create a new reactive root. This root is leaked and so lives until the end of the program.
     pub fn new_static() -> &'static Self {
         let this = Self {
-            tracker: RefCell::new(None),
+            tracker: RefCell::new(MaybeDependencyTracker::default()),
             rev_sorted_buf: RefCell::new(Vec::new()),
             current_node: Cell::new(NodeId::null()),
             root_node: Cell::new(NodeId::null()),
@@ -105,9 +105,9 @@ impl Root {
     /// Run the provided closure in a tracked scope. This will detect all the signals that are
     /// accessed and track them in a dependency list.
     pub fn tracked_scope<T>(&self, f: impl FnOnce() -> T) -> (T, DependencyTracker) {
-        let prev = self.tracker.replace(Some(DependencyTracker::default()));
+        let prev = self.tracker.replace(MaybeDependencyTracker::Tracking(DependencyTracker::default()));
         let ret = f();
-        (ret, self.tracker.replace(prev).unwrap())
+        (ret, self.tracker.replace(prev).into_tracker().unwrap())
     }
 
     /// Ensure that the node is clean. If it is dirty, then we need to update the node first before
@@ -313,6 +313,24 @@ impl RootHandle {
     }
 }
 
+#[derive(Default)]
+pub(crate) enum MaybeDependencyTracker {
+    Tracking(DependencyTracker),
+    #[default]
+    Untracked,
+    UntrackedInComponent,
+}
+
+impl MaybeDependencyTracker {
+    pub fn into_tracker(self) -> Option<DependencyTracker> {
+        if let Self::Tracking(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+}
+
 /// Tracks nodes that are accessed inside a reactive scope.
 #[derive(Default)]
 pub(crate) struct DependencyTracker {
@@ -458,10 +476,19 @@ pub fn untrack<T>(f: impl FnOnce() -> T) -> T {
 
 /// Same as [`untrack`] but for a specific [`Root`].
 pub(crate) fn untrack_in_scope<T>(f: impl FnOnce() -> T, root: &'static Root) -> T {
-    let prev = root.tracker.replace(None);
+    untrack_in_scope_with_maybe_tracker(f, root, MaybeDependencyTracker::Untracked)
+}
+
+fn untrack_in_scope_with_maybe_tracker<T>(f: impl FnOnce() -> T, root: &'static Root, maybe_tracker: MaybeDependencyTracker) -> T {
+    let prev = root.tracker.replace(maybe_tracker);
     let ret = f();
     root.tracker.replace(prev);
     ret
+}
+
+/// Same as [`untrack`] but creates warnings if any tracking is performed.
+pub fn untrack_in_component<T>(f: impl FnOnce() -> T) -> T {
+    untrack_in_scope_with_maybe_tracker(f, Root::global(), MaybeDependencyTracker::UntrackedInComponent)
 }
 
 /// Get a handle to the current reactive scope.

--- a/packages/sycamore-reactive/src/signals.rs
+++ b/packages/sycamore-reactive/src/signals.rs
@@ -357,8 +357,31 @@ impl<T> ReadSignal<T> {
     /// # });
     /// ```
     pub fn track(self) {
-        if let Some(tracker) = &mut *self.root.tracker.borrow_mut() {
-            tracker.dependencies.push(self.id);
+        match &mut *self.root.tracker.borrow_mut() {
+            MaybeDependencyTracker::Tracking(tracker) => {
+                tracker.dependencies.push(self.id);
+            }
+            MaybeDependencyTracker::Untracked => (),
+            MaybeDependencyTracker::UntrackedInComponent => {
+                #[cfg(debug_assertions)]
+                panic!("
+You accessed a ReadSignal (defined at {}) in a component body. This might mean your app is not responding to changes in signal values in the way you expect.
+
+Here’s how to fix it:
+
+1. If this is inside a `view!` macro, make sure you are passing a function, not a value:
+  ❌ NO  p {{ (x.get() * 2) }}
+  ✅ YES p {{ (move || x.get() * 2) }}
+
+2. If it’s in the body of a component, try wrapping this access in a closure:
+  ❌ NO  let y = x.get() * 2;
+  ✅ YES let y = move || x.get() * 2;
+                ",
+                    self.created_at
+                );
+                #[cfg(not(debug_assertions))]
+                panic!("accessed a ReadSignal in a component body")
+            }
         }
     }
 }
@@ -890,6 +913,17 @@ mod tests {
             signal.update(|value| value.push_str("World!"));
             assert_eq!(signal.get_clone(), "Hello World!");
             assert_eq!(counter.get(), 2);
+        });
+    }
+
+    #[test]
+    #[should_panic = "component body"]
+    fn signal_in_component_body() {
+        let _ = create_root(|| {
+            let signal = create_signal(());
+            untrack_in_component(move || {
+                signal.get();
+            })
         });
     }
 }

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -342,7 +342,9 @@ where
 {
     let StaticRouterProps { view, route } = props;
 
-    view(*create_signal(route))
+    // StaticRouter runs only once on the client, so we don't need reactivity of the route.
+    // TODO(breaking change) StaticRouter could pass R directly instead of ReadSignal<R> to reflect this.
+    untrack(move || view(*create_signal(route)))
 }
 
 /// Navigates to the specified `url`. The url should have the same origin as the app.

--- a/packages/sycamore-router/src/router.rs
+++ b/packages/sycamore-router/src/router.rs
@@ -343,7 +343,8 @@ where
     let StaticRouterProps { view, route } = props;
 
     // StaticRouter runs only once on the client, so we don't need reactivity of the route.
-    // TODO(breaking change) StaticRouter could pass R directly instead of ReadSignal<R> to reflect this.
+    // TODO(breaking change) StaticRouter could pass R directly instead of ReadSignal<R> to reflect
+    // this.
     untrack(move || view(*create_signal(route)))
 }
 

--- a/packages/sycamore-web/src/iter.rs
+++ b/packages/sycamore-web/src/iter.rs
@@ -87,15 +87,18 @@ where
         // In SSR mode, just create a static view.
         let start = HtmlNode::create_marker_node();
         let end = HtmlNode::create_marker_node();
-        View::from((
-            start,
-            list.into()
-                .evaluate()
-                .into_iter()
-                .map(|x| view(x).into())
-                .collect::<Vec<_>>(),
-            end,
-        ))
+        // Tracking doesn't matter on the server.
+        untrack(|| {
+            View::from((
+                start,
+                list.into()
+                    .evaluate()
+                    .into_iter()
+                    .map(|x| view(x).into())
+                    .collect::<Vec<_>>(),
+                end,
+            ))
+        })
     } else {
         let start = HtmlNode::create_marker_node();
         let start_node = start.as_web_sys().clone();
@@ -193,15 +196,18 @@ where
         // In SSR mode, just create a static view.
         let start = HtmlNode::create_marker_node();
         let end = HtmlNode::create_marker_node();
-        View::from((
-            start,
-            list.into()
-                .evaluate()
-                .into_iter()
-                .map(|x| view(x).into())
-                .collect::<Vec<_>>(),
-            end,
-        ))
+        // Tracking doesn't matter on the server.
+        untrack(|| {
+            View::from((
+                start,
+                list.into()
+                    .evaluate()
+                    .into_iter()
+                    .map(|x| view(x).into())
+                    .collect::<Vec<_>>(),
+                end,
+            ))
+        })
     } else {
         let start = HtmlNode::create_marker_node();
         let start_node = start.as_web_sys().clone();

--- a/packages/sycamore-web/src/suspense.rs
+++ b/packages/sycamore-web/src/suspense.rs
@@ -307,7 +307,7 @@ pub fn use_suspense_key() -> NonZeroU32 {
     let global_scope = use_global_scope();
     let counter = global_scope.run_in(|| use_context_or_else(SuspenseCounter::new));
 
-    let next = counter.next.get();
-    counter.next.set(next.checked_add(1).unwrap());
+    let next = counter.next.get_untracked();
+    counter.next.set_silent(next.checked_add(1).unwrap());
     next
 }


### PR DESCRIPTION
Creates a warning when a signal is accessed inside a component's body which recommends that the programmer uses a closure. The message is based on the same warning in Leptos.

The implementation works and passes all the tests. The main reason it's still a draft is it creates panics, not warnings which would be a breaking change. It's unclear how sycamore-reactive can call e.g. `sycamore-web::console_warn!`.